### PR TITLE
Add phone extraction and auto-name lead forms

### DIFF
--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -62,6 +62,9 @@ class MetaLeadFormAgent:
 
         try:
             payload = LeadFormPayload.model_validate_json(content)
+            if len(payload.name) > 50:
+                payload.name = payload.name[:50]
+                payload.name = re.sub(r'\s+\S*$', '', payload.name)
         except ValidationError as e:
             logger.error("Failed to parse LLM output", error=str(e), raw=content)
             raise AIProcessingException("LLM output is not valid JSON")

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -1,4 +1,6 @@
 import structlog
+from datetime import datetime
+import re
 from pydantic import ValidationError
 
 from core.models.lead_form import LeadFormPayload
@@ -83,6 +85,13 @@ class MetaLeadFormAgent:
                 session_id=session_id
             )
 
+        phone = self._extract_phone(summary)
+        phone = self._normalize_phone(phone)
+
+        if phone:
+            payload.thank_you_page.business_phone_number = phone
+            payload.thank_you_page.button_type = "CALL_BUSINESS"    
+
         return payload
 
     async def create_lead_form(
@@ -108,6 +117,15 @@ class MetaLeadFormAgent:
 
         if not payload.name:
             raise BusinessValidationException("Form name is required")    
+
+        clean_name = re.sub(r'[^a-zA-Z0-9 ]', '', payload.name)
+
+        now = datetime.now()
+        date_part = now.strftime("%d%b")   
+        time_part = now.strftime("%H%M%S")    
+        payload.name = f"{clean_name[:30]}_{date_part}_{time_part}"    
+
+        logger.info("Final Lead Form Name", name=payload.name)
 
         meta_payload = payload.model_dump(exclude_none=True)
 
@@ -174,6 +192,34 @@ class MetaLeadFormAgent:
                 return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
 
         return None
+
+    def _extract_phone(self, text: str) -> str | None:
+        matches = re.findall(r'\+\d[\d\s\-\(\)]{7,15}', text)
+        if matches:
+            return matches[0]
+
+        matches = re.findall(r'0[\d\s\-\(\)]{9,15}', text)
+        if matches:
+            return matches[0]
+        match = re.search(r'\b\d{10}\b', text)
+        return match.group(0) if match else None
+
+    def _normalize_phone(self, phone: str | None) -> str | None:
+        if not phone:
+            return None
+
+        phone = re.sub(r"[^\d+]", "", phone)
+
+        if phone.startswith("+"):
+            return phone
+
+        if phone.startswith("0"):
+            phone = phone[1:]
+
+        if phone.isdigit():
+            return "+91" + phone
+
+        return phone    
 
 
 meta_lead_form_agent = MetaLeadFormAgent()

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -46,6 +46,15 @@ If content has:
 - 1 item → style = PARAGRAPH_STYLE
 - 2–5 items → style = LIST_STYLE
 
+IMPORTANT:
+
+- Each content bullet MUST be under 80 characters
+- Keep bullets short, crisp, and benefit-focused
+- Avoid long sentences and extra descriptions
+- Prefer phrases over full sentences
+- DO NOT exceed 80 characters under any condition
+- If any bullet exceeds 80 characters, rewrite it to fit within limit
+
 ---
 
 QUESTIONS


### PR DESCRIPTION
Add phone parsing and normalization and automatic, timestamped form naming. Imports for datetime and re were added. If a phone is found in the summary, it is normalized (non-digits removed, leading 0 converted and prefixed with +91 if needed, or preserved if already +) and set on payload.thank_you_page with button_type = "CALL_BUSINESS". Form names are cleaned of special characters, truncated to 30 chars, and suffixed with current day/month and time (DDMon_HHMMSS) to ensure uniqueness; final name is logged. Helper methods _extract_phone and _normalize_phone implement the regex matching and normalization logic.