### PR TITLE
Improve lead form parsing and phone handling

### DIFF
--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -1,6 +1,7 @@
 import structlog
 from datetime import datetime
 import re
+import json
 from pydantic import ValidationError
 
 from core.models.lead_form import LeadFormPayload
@@ -47,7 +48,7 @@ class MetaLeadFormAgent:
 
         logger.info("Generating Meta lead form", session_id=session_id)
 
-        prompt = LEAD_FORM_PROMPT.format(summary=summary)
+        prompt = LEAD_FORM_PROMPT.format(summary=summary, website_url=website_data.business_url)
 
         messages = [
             {"role": "system", "content": "You are a backend API. Always return valid JSON only."},
@@ -61,11 +62,14 @@ class MetaLeadFormAgent:
             raise AIProcessingException("LLM returned empty response")
 
         try:
-            payload = LeadFormPayload.model_validate_json(content)
-            if len(payload.name) > 50:
-                payload.name = payload.name[:50]
-                payload.name = re.sub(r'\s+\S*$', '', payload.name)
-        except ValidationError as e:
+            data = json.loads(content)
+
+            if "name" in data and len(data["name"]) > 50:
+                data["name"] = data["name"][:50]
+                data["name"] = re.sub(r'\s+\S*$', '', data["name"])
+
+            payload = LeadFormPayload.model_validate(data)
+        except Exception as e:
             logger.error("Failed to parse LLM output", error=str(e), raw=content)
             raise AIProcessingException("LLM output is not valid JSON")
 
@@ -93,7 +97,14 @@ class MetaLeadFormAgent:
 
         if phone:
             payload.thank_you_page.business_phone_number = phone
-            payload.thank_you_page.button_type = "CALL_BUSINESS"    
+            payload.thank_you_page.button_type = "CALL_BUSINESS"  
+            payload.thank_you_page.country_code = "IN" 
+
+        else:
+            payload.thank_you_page.button_type = "VIEW_WEBSITE"
+
+        if payload.thank_you_page.button_type == "VIEW_WEBSITE":
+            payload.thank_you_page.website_url = website_data.business_url
 
         return payload
 
@@ -122,6 +133,7 @@ class MetaLeadFormAgent:
             raise BusinessValidationException("Form name is required")    
 
         clean_name = re.sub(r'[^a-zA-Z0-9 ]', '', payload.name)
+        clean_name = re.sub(r'\s+', ' ', clean_name).strip()
 
         now = datetime.now()
         date_part = now.strftime("%d%b")   
@@ -194,18 +206,18 @@ class MetaLeadFormAgent:
             if any(k in href.lower() or k in text for k in ["policy", "terms", "legal"]):
                 return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
 
-        return None
+        return None        
 
     def _extract_phone(self, text: str) -> str | None:
         matches = re.findall(r'\+\d[\d\s\-\(\)]{7,15}', text)
         if matches:
             return matches[0]
 
-        matches = re.findall(r'0[\d\s\-\(\)]{9,15}', text)
+        matches = re.findall(r'\b(?:\d[\s\-\(\)]*){10,12}\b', text)
         if matches:
-            return matches[0]
-        match = re.search(r'\b\d{10}\b', text)
-        return match.group(0) if match else None
+            return max(matches, key=len)
+
+        return None
 
     def _normalize_phone(self, phone: str | None) -> str | None:
         if not phone:
@@ -213,16 +225,19 @@ class MetaLeadFormAgent:
 
         phone = re.sub(r"[^\d+]", "", phone)
 
-        if phone.startswith("+"):
+        if phone.startswith("+91"):
             return phone
+
+        if phone.startswith("+"):
+            phone = phone.lstrip("+")
 
         if phone.startswith("0"):
             phone = phone[1:]
 
         if phone.isdigit():
-            return "+91" + phone
+            return "+91" + phone[-10:]
 
-        return phone    
+        return None
 
 
 meta_lead_form_agent = MetaLeadFormAgent()

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -195,12 +195,42 @@ class MetaLeadFormAgent:
 
         meta_payload = payload.model_dump(exclude_none=True)
 
-        if "enable_otp_verification" in meta_payload:
-            if payload.enable_otp_verification:
-                meta_payload["phone_verification"] = True
-            del meta_payload["enable_otp_verification"]
+        enable_otp = getattr(payload, "enable_otp_verification", False)
 
-        logger.info("Creating Meta lead form", payload=meta_payload)
+        meta_payload["is_optimized_for_quality"] = payload.is_optimized_for_quality
+        meta_payload["is_phone_sms_verify_enabled"] = (
+            bool(enable_otp) and payload.is_optimized_for_quality
+        )
+
+        for field in [
+            "enable_otp_verification",
+            "intent",
+            "is_verification_required",
+            "block_display_for_review",
+        ]:
+            meta_payload.pop(field, None)
+
+        questions = meta_payload.get("questions", [])
+        has_phone = False
+        for q in questions:
+            if isinstance(q, dict) and q.get("type") == "PHONE":
+                has_phone = True
+                q.pop("is_required", None)
+                break
+
+        if enable_otp and not has_phone:
+            logger.warning(
+                "OTP verification enabled but no PHONE field found. "
+                "Meta will likely ignore is_phone_sms_verify_enabled."
+            )
+
+        logger.info(
+            "Creating Meta lead form",
+            name=payload.name,
+            is_optimized_for_quality=True,
+            is_phone_sms_verify_enabled=bool(enable_otp),
+            has_phone_field=has_phone,
+        )
 
         result = await self.lead_form_adapter.create(
             client_code=auth_context.client_code,

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -1,10 +1,11 @@
 import structlog
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 import json
+from json import JSONDecodeError
 from pydantic import ValidationError
 
-from core.models.lead_form import LeadFormPayload
+from core.models.lead_form import LeadFormPayload, ThankYouPageButtonType
 from services.business_service import BusinessService
 from services.session_manager import sessions
 from agents.shared.llm import chat_completion
@@ -12,11 +13,12 @@ from utils.prompt_loader import load_prompt
 from exceptions.custom_exceptions import (
     BusinessValidationException,
     AIProcessingException,
+    SessionException
 )
 
 from adapters.meta.lead_forms import MetaLeadFormAdapter
 
-from oserver.services.storage_service import StorageService
+from oserver.services.storage_service import storage_service
 from oserver.models.storage_request_model import StorageRequest
 from core.infrastructure.context import auth_context
 
@@ -24,18 +26,23 @@ logger = structlog.get_logger()
 
 LEAD_FORM_PROMPT = load_prompt("meta/lead_form.txt")
 
+DEFAULT_COUNTRY_CODE = "IN"
+DEFAULT_PHONE_PREFIX = "+91"
+STORAGE_NAME = "AISuggestedData"
+APP_CODE = "marketingai"
+
 
 class MetaLeadFormAgent:
 
     def __init__(self):
         self.business_service = BusinessService()
-        self.storage_service = StorageService()
+        self.storage_service = storage_service
         self.lead_form_adapter = MetaLeadFormAdapter()
 
     async def generate_payload(self, session_id: str) -> LeadFormPayload:
 
         if session_id not in sessions:
-            raise BusinessValidationException("Session not found")
+            raise SessionException(session_id=session_id)
 
         website_data = await self.business_service.fetch_website_data(session_id)
 
@@ -55,7 +62,20 @@ class MetaLeadFormAgent:
             {"role": "user", "content": prompt},
         ]
 
-        response = await chat_completion(messages)
+        response = None
+        max_retries = 2
+
+        for attempt in range(max_retries):
+            try:
+                response = await chat_completion(
+                    messages,
+                    response_format={"type": "json_object"}
+                )
+                break
+            except Exception as e:
+                logger.warning("LLM call failed, retrying...", attempt=attempt, error=str(e))
+                if attempt == max_retries - 1:
+                    raise AIProcessingException("LLM call failed after retries")
         content = response.choices[0].message.content
 
         if not content:
@@ -63,25 +83,28 @@ class MetaLeadFormAgent:
 
         try:
             data = json.loads(content)
+        except JSONDecodeError as e:
+            logger.error("Invalid JSON from LLM", error=str(e), raw=content)
+            raise AIProcessingException("LLM returned invalid JSON")
 
+        try:
             payload = LeadFormPayload.model_validate(data)
+        except ValidationError as e:
+            logger.error("LLM JSON structure mismatch", error=str(e), data=data)
+            raise AIProcessingException("LLM returned incorrect data structure")
 
-            business_name = self.extract_business_name(summary, website_data.business_url)
+        base_name = (payload.name or "").strip()
 
-            now = datetime.now()
-            date_part = now.strftime("%d/%m/%Y")
-            time_part = now.strftime("%H:%M:%S")
+        if not base_name:
+            base_name = self.extract_business_name(summary, website_data.business_url)
 
-            full_name = f"{business_name} {date_part} {time_part}"
+        base_name = base_name[:25]
 
-            if len(full_name) > 50:
-                full_name = full_name[:50]
-                full_name = re.sub(r'\s+\S*$', '', full_name)
+        now = datetime.now(timezone.utc)
+        date_part = now.strftime("%d/%m/%Y")
+        time_part = now.strftime("%H:%M:%S")
 
-            payload.name = full_name
-        except Exception as e:
-            logger.error("Failed to parse LLM output", error=str(e), raw=content)
-            raise AIProcessingException("LLM output is not valid JSON")
+        payload.name = f"{base_name} {date_part} {time_part}"
 
         site_links = await self._fetch_site_links(website_data.storage_id)
 
@@ -92,9 +115,7 @@ class MetaLeadFormAgent:
             website_data.business_url
         )
 
-        payload.privacy_policy.url = (
-            privacy_link if privacy_link else website_data.business_url
-        )
+        payload.privacy_policy.url = privacy_link or website_data.business_url
 
         if not privacy_link:
             logger.warning(
@@ -102,18 +123,17 @@ class MetaLeadFormAgent:
                 session_id=session_id
             )
 
-        phone = self._extract_phone(summary)
-        phone = self._normalize_phone(phone)
+        normalized_phone = self._normalize_phone(self._extract_phone(summary))
 
-        if phone:
-            payload.thank_you_page.business_phone_number = phone
-            payload.thank_you_page.button_type = "CALL_BUSINESS"  
-            payload.thank_you_page.country_code = "IN" 
+        if normalized_phone:
+            payload.thank_you_page.business_phone_number = normalized_phone
+            payload.thank_you_page.button_type = ThankYouPageButtonType.CALL_BUSINESS 
+            payload.thank_you_page.country_code = DEFAULT_COUNTRY_CODE
 
         else:
-            payload.thank_you_page.button_type = "VIEW_WEBSITE"
+            payload.thank_you_page.button_type = ThankYouPageButtonType.VIEW_WEBSITE
 
-        if payload.thank_you_page.button_type == "VIEW_WEBSITE":
+        if payload.thank_you_page.button_type == ThankYouPageButtonType.VIEW_WEBSITE:
             payload.thank_you_page.website_url = website_data.business_url
 
         return payload
@@ -124,9 +144,10 @@ class MetaLeadFormAgent:
         payload: LeadFormPayload,
     ) -> dict:
 
-        session = sessions.get(session_id)
-        if not session:
-            raise BusinessValidationException("Session not found")
+        if session_id not in sessions:
+            raise SessionException(session_id=session_id)
+        
+        session = sessions[session_id]
         
         ad_plan = session.get("ad_plan") or {}
 
@@ -163,40 +184,32 @@ class MetaLeadFormAgent:
             return []
 
         request = StorageRequest(
-            storageName="AISuggestedData",
-            appCode="marketingai",
+            storageName=STORAGE_NAME,
+            appCode=APP_CODE,
             dataObjectId=storage_id,
             clientCode=auth_context.client_code,
         )
 
         response = await self.storage_service.read_storage(request)
 
-        if not response.success or not response.result:
+        if not response.success or not response.content:
             logger.error("No site links found in storage", storage_id=storage_id)
             return []  
 
-        record = response.result
-
-        if isinstance(record, list) and len(record) > 0:
-            record = record[0]
-
-        data = record.get("result", {})
-
-        while isinstance(data, dict) and "result" in data:
-            data = data["result"]
-
-        site_links = data.get("siteLinks", [])
-
-        return site_links 
+        record = response.content[0]
+        return record.get("siteLinks", [])
 
     def _extract_privacy_policy(self, links, base_url):
 
-        if not links:
+        if not links or not base_url:
             return None
 
         for link in links:
             href = (link.get("href") or "").strip()
             text = (link.get("text") or "").lower()
+
+            if not href or href == "#":
+                continue
 
             if "privacy" in href.lower() or "privacy" in text:
                 return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
@@ -204,6 +217,9 @@ class MetaLeadFormAgent:
         for link in links:
             href = (link.get("href") or "").strip()
             text = (link.get("text") or "").lower()
+
+            if not href or href == "#":
+                continue
 
             if any(k in href.lower() or k in text for k in ["policy", "terms", "legal"]):
                 return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
@@ -227,31 +243,15 @@ class MetaLeadFormAgent:
 
         phone = re.sub(r"[^\d+]", "", phone)
 
-        if phone.startswith("+91"):
+        if phone.startswith("+"):
             return phone
 
-        if phone.startswith("+"):
-            phone = phone.lstrip("+")
-
-        if phone.startswith("0"):
-            phone = phone[1:]
-
-        if phone.isdigit():
-            return "+91" + phone[-10:]
+        if phone.isdigit() and len(phone[-10:]) == 10:
+            return DEFAULT_PHONE_PREFIX + phone[-10:]
 
         return None
 
     def extract_business_name(self, summary: str, website_url: str) -> str:
-
-        first_line = summary.split(".")[0]
-
-        ignore_words = {"Experience", "Discover", "Welcome", "Introducing", "Explore"}
-
-        matches = re.findall(r'([A-Z][a-zA-Z]+(?:\s(?:and|&|of|the|[A-Z][a-zA-Z]+))*)', first_line)
-
-        for match in matches:
-            if match.split()[0] not in ignore_words and len(match) > 2:
-                return match.strip()
 
         if website_url:
             domain = website_url.replace("https://", "").replace("http://", "").split("/")[0]

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -247,10 +247,10 @@ class MetaLeadFormAgent:
 
         ignore_words = {"Experience", "Discover", "Welcome", "Introducing", "Explore"}
 
-        matches = re.findall(r'([A-Z][a-zA-Z&]+(?:\s[A-Z][a-zA-Z&]+)*)', first_line)
+        matches = re.findall(r'([A-Z][a-zA-Z]+(?:\s(?:and|&|of|the|[A-Z][a-zA-Z]+))*)', first_line)
 
         for match in matches:
-            if match not in ignore_words and len(match) > 2:
+            if match.split()[0] not in ignore_words and len(match) > 2:
                 return match.strip()
 
         if website_url:

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -64,11 +64,21 @@ class MetaLeadFormAgent:
         try:
             data = json.loads(content)
 
-            if "name" in data and len(data["name"]) > 50:
-                data["name"] = data["name"][:50]
-                data["name"] = re.sub(r'\s+\S*$', '', data["name"])
-
             payload = LeadFormPayload.model_validate(data)
+
+            business_name = self.extract_business_name(summary, website_data.business_url)
+
+            now = datetime.now()
+            date_part = now.strftime("%d/%m/%Y")
+            time_part = now.strftime("%H:%M:%S")
+
+            full_name = f"{business_name} {date_part} {time_part}"
+
+            if len(full_name) > 50:
+                full_name = full_name[:50]
+                full_name = re.sub(r'\s+\S*$', '', full_name)
+
+            payload.name = full_name
         except Exception as e:
             logger.error("Failed to parse LLM output", error=str(e), raw=content)
             raise AIProcessingException("LLM output is not valid JSON")
@@ -131,15 +141,7 @@ class MetaLeadFormAgent:
 
         if not payload.name:
             raise BusinessValidationException("Form name is required")    
-
-        clean_name = re.sub(r'[^a-zA-Z0-9 ]', '', payload.name)
-        clean_name = re.sub(r'\s+', ' ', clean_name).strip()
-
-        now = datetime.now()
-        date_part = now.strftime("%d%b")   
-        time_part = now.strftime("%H%M%S")    
-        payload.name = f"{clean_name[:30]}_{date_part}_{time_part}"    
-
+             
         logger.info("Final Lead Form Name", name=payload.name)
 
         meta_payload = payload.model_dump(exclude_none=True)
@@ -238,6 +240,24 @@ class MetaLeadFormAgent:
             return "+91" + phone[-10:]
 
         return None
+
+    def extract_business_name(self, summary: str, website_url: str) -> str:
+
+        first_line = summary.split(".")[0]
+
+        ignore_words = {"Experience", "Discover", "Welcome", "Introducing", "Explore"}
+
+        matches = re.findall(r'([A-Z][a-zA-Z&]+(?:\s[A-Z][a-zA-Z&]+)*)', first_line)
+
+        for match in matches:
+            if match not in ignore_words and len(match) > 2:
+                return match.strip()
+
+        if website_url:
+            domain = website_url.replace("https://", "").replace("http://", "").split("/")[0]
+            return domain.split(".")[0].title()
+
+        return "LeadForm"    
 
 
 meta_lead_form_agent = MetaLeadFormAgent()

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -1,5 +1,6 @@
 import structlog
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 import re
 import json
 from json import JSONDecodeError
@@ -13,7 +14,7 @@ from utils.prompt_loader import load_prompt
 from exceptions.custom_exceptions import (
     BusinessValidationException,
     AIProcessingException,
-    SessionException
+    SessionException,
 )
 
 from adapters.meta.lead_forms import MetaLeadFormAdapter
@@ -33,10 +34,8 @@ APP_CODE = "marketingai"
 
 
 class MetaLeadFormAgent:
-
     def __init__(self):
         self.business_service = BusinessService()
-        self.storage_service = storage_service
         self.lead_form_adapter = MetaLeadFormAdapter()
 
     async def generate_payload(self, session_id: str) -> LeadFormPayload:
@@ -55,52 +54,82 @@ class MetaLeadFormAgent:
 
         logger.info("Generating Meta lead form", session_id=session_id)
 
-        prompt = LEAD_FORM_PROMPT.format(summary=summary, website_url=website_data.business_url)
+        prompt = LEAD_FORM_PROMPT.format(
+            summary=summary, website_url=website_data.business_url
+        )
 
         messages = [
-            {"role": "system", "content": "You are a backend API. Always return valid JSON only."},
+            {
+                "role": "system",
+                "content": "You are a backend API. Always return valid JSON only.",
+            },
             {"role": "user", "content": prompt},
         ]
 
-        response = None
-        max_retries = 2
+        payload = None
+        max_retries = 3
 
         for attempt in range(max_retries):
             try:
                 response = await chat_completion(
-                    messages,
-                    response_format={"type": "json_object"}
+                    messages, response_format={"type": "json_object"}
                 )
+                content = response.choices[0].message.content
+
+                if not content:
+                    raise AIProcessingException("LLM returned empty response")
+
+                data = json.loads(content)
+                payload = LeadFormPayload.model_validate(data)
+
+                if payload.enable_otp_verification:
+                    if not payload.is_optimized_for_quality:
+                        payload.enable_otp_verification = False
+
+                    else:
+                        has_phone = any(q.type == "PHONE" for q in payload.questions)
+
+                        if not has_phone:
+                            payload.enable_otp_verification = False
+
                 break
-            except Exception as e:
-                logger.warning("LLM call failed, retrying...", attempt=attempt, error=str(e))
+
+            except (JSONDecodeError, ValidationError) as e:
+                logger.warning(
+                    "LLM validation failed, retrying...",
+                    attempt=attempt,
+                    error=str(e),
+                )
                 if attempt == max_retries - 1:
-                    raise AIProcessingException("LLM call failed after retries")
-        content = response.choices[0].message.content
+                    raise AIProcessingException(
+                        f"LLM call failed after retries: {str(e)}"
+                    )
 
-        if not content:
-            raise AIProcessingException("LLM returned empty response")
-
-        try:
-            data = json.loads(content)
-        except JSONDecodeError as e:
-            logger.error("Invalid JSON from LLM", error=str(e), raw=content)
-            raise AIProcessingException("LLM returned invalid JSON")
-
-        try:
-            payload = LeadFormPayload.model_validate(data)
-        except ValidationError as e:
-            logger.error("LLM JSON structure mismatch", error=str(e), data=data)
-            raise AIProcessingException("LLM returned incorrect data structure")
+                messages.append({"role": "assistant", "content": content or "{}"})
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": f"Your last response failed validation with this error: {str(e)}. Please fix the JSON structure to satisfy the schema.",
+                    }
+                )
 
         base_name = (payload.name or "").strip()
 
         if not base_name:
-            base_name = self.extract_business_name(summary, website_data.business_url)
+            base_name = self.get_fallback_business_name(
+                summary, website_data.business_url
+            )
 
         base_name = base_name[:25]
 
-        now = datetime.now(timezone.utc)
+        timezone_str = getattr(auth_context, "timezone", "UTC")
+
+        try:
+            tz = ZoneInfo(timezone_str)
+        except Exception:
+            tz = ZoneInfo("UTC")
+
+        now = datetime.now(tz)
         date_part = now.strftime("%d/%m/%Y")
         time_part = now.strftime("%H:%M:%S")
 
@@ -111,8 +140,7 @@ class MetaLeadFormAgent:
         logger.info("Fetched site links", site_links=site_links)
 
         privacy_link = self._extract_privacy_policy(
-            site_links,
-            website_data.business_url
+            site_links, website_data.business_url
         )
 
         payload.privacy_policy.url = privacy_link or website_data.business_url
@@ -120,14 +148,14 @@ class MetaLeadFormAgent:
         if not privacy_link:
             logger.warning(
                 "Privacy policy URL not found, falling back to business URL",
-                session_id=session_id
+                session_id=session_id,
             )
 
         normalized_phone = self._normalize_phone(self._extract_phone(summary))
 
         if normalized_phone:
             payload.thank_you_page.business_phone_number = normalized_phone
-            payload.thank_you_page.button_type = ThankYouPageButtonType.CALL_BUSINESS 
+            payload.thank_you_page.button_type = ThankYouPageButtonType.CALL_BUSINESS
             payload.thank_you_page.country_code = DEFAULT_COUNTRY_CODE
 
         else:
@@ -135,6 +163,12 @@ class MetaLeadFormAgent:
 
         if payload.thank_you_page.button_type == ThankYouPageButtonType.VIEW_WEBSITE:
             payload.thank_you_page.website_url = website_data.business_url
+
+        if payload.thank_you_page.button_type == ThankYouPageButtonType.CALL_BUSINESS:
+            payload.thank_you_page.button_text = "Call Now"
+
+        elif payload.thank_you_page.button_type == ThankYouPageButtonType.VIEW_WEBSITE:
+            payload.thank_you_page.button_text = "Visit Website"
 
         return payload
 
@@ -146,9 +180,9 @@ class MetaLeadFormAgent:
 
         if session_id not in sessions:
             raise SessionException(session_id=session_id)
-        
+
         session = sessions[session_id]
-        
+
         ad_plan = session.get("ad_plan") or {}
 
         page_id = ad_plan.get("metaPageId") or session.get("metaPageId")
@@ -157,15 +191,14 @@ class MetaLeadFormAgent:
         if not page_id:
             page_id = "332515906622723"
 
-        if not payload.questions:
-            raise BusinessValidationException("At least one question is required")
-
-        if not payload.name:
-            raise BusinessValidationException("Form name is required")    
-             
         logger.info("Final Lead Form Name", name=payload.name)
 
         meta_payload = payload.model_dump(exclude_none=True)
+
+        if "enable_otp_verification" in meta_payload:
+            if payload.enable_otp_verification:
+                meta_payload["phone_verification"] = True
+            del meta_payload["enable_otp_verification"]
 
         logger.info("Creating Meta lead form", payload=meta_payload)
 
@@ -190,11 +223,11 @@ class MetaLeadFormAgent:
             clientCode=auth_context.client_code,
         )
 
-        response = await self.storage_service.read_storage(request)
+        response = await storage_service.read_storage(request)
 
         if not response.success or not response.content:
             logger.error("No site links found in storage", storage_id=storage_id)
-            return []  
+            return []
 
         record = response.content[0]
         return record.get("siteLinks", [])
@@ -212,7 +245,11 @@ class MetaLeadFormAgent:
                 continue
 
             if "privacy" in href.lower() or "privacy" in text:
-                return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
+                return (
+                    href
+                    if href.startswith("http")
+                    else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
+                )
 
         for link in links:
             href = (link.get("href") or "").strip()
@@ -221,17 +258,23 @@ class MetaLeadFormAgent:
             if not href or href == "#":
                 continue
 
-            if any(k in href.lower() or k in text for k in ["policy", "terms", "legal"]):
-                return href if href.startswith("http") else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
+            if any(
+                k in href.lower() or k in text for k in ["policy", "terms", "legal"]
+            ):
+                return (
+                    href
+                    if href.startswith("http")
+                    else f"{base_url.rstrip('/')}/{href.lstrip('/')}"
+                )
 
-        return None        
+        return None
 
     def _extract_phone(self, text: str) -> str | None:
-        matches = re.findall(r'\+\d[\d\s\-\(\)]{7,15}', text)
+        matches = re.findall(r"\+\d[\d\s\-\(\)]{7,15}", text)
         if matches:
             return matches[0]
 
-        matches = re.findall(r'\b(?:\d[\s\-\(\)]*){10,12}\b', text)
+        matches = re.findall(r"\b(?:\d[\s\-\(\)]*){10,12}\b", text)
         if matches:
             return max(matches, key=len)
 
@@ -251,13 +294,15 @@ class MetaLeadFormAgent:
 
         return None
 
-    def extract_business_name(self, summary: str, website_url: str) -> str:
+    def get_fallback_business_name(self, summary: str, website_url: str) -> str:
 
         if website_url:
-            domain = website_url.replace("https://", "").replace("http://", "").split("/")[0]
+            domain = (
+                website_url.replace("https://", "").replace("http://", "").split("/")[0]
+            )
             return domain.split(".")[0].title()
 
-        return "LeadForm"    
+        return "LeadForm"
 
 
 meta_lead_form_agent = MetaLeadFormAgent()

--- a/agents/meta/lead_form_agent.py
+++ b/agents/meta/lead_form_agent.py
@@ -1,12 +1,16 @@
 import structlog
 from datetime import datetime
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import re
 import json
 from json import JSONDecodeError
 from pydantic import ValidationError
-
-from core.models.lead_form import LeadFormPayload, ThankYouPageButtonType
+from core.models.lead_form import (
+    LeadFormPayload,
+    ThankYouPageButtonType,
+    QuestionType,
+    LeadFormCreateResponse,
+)
 from services.business_service import BusinessService
 from services.session_manager import sessions
 from agents.shared.llm import chat_completion
@@ -16,21 +20,20 @@ from exceptions.custom_exceptions import (
     AIProcessingException,
     SessionException,
 )
-
 from adapters.meta.lead_forms import MetaLeadFormAdapter
-
 from oserver.services.storage_service import storage_service
 from oserver.models.storage_request_model import StorageRequest
 from core.infrastructure.context import auth_context
 
 logger = structlog.get_logger()
-
 LEAD_FORM_PROMPT = load_prompt("meta/lead_form.txt")
 
 DEFAULT_COUNTRY_CODE = "IN"
 DEFAULT_PHONE_PREFIX = "+91"
 STORAGE_NAME = "AISuggestedData"
 APP_CODE = "marketingai"
+MAX_LLM_RETRIES = 3
+MAX_BRAND_NAME_LENGTH = 25
 
 
 class MetaLeadFormAgent:
@@ -52,10 +55,38 @@ class MetaLeadFormAgent:
                 "Missing summary in product data. Please complete website analysis."
             )
 
-        logger.info("Generating Meta lead form", session_id=session_id)
+        logger.info(
+            "Generating Meta lead form",
+            session_id=session_id,
+            client_code=auth_context.client_code,
+        )
+
+        payload = await self._get_lead_form_from_llm(summary, website_data.business_url)
+
+        self._apply_timestamped_name(payload, summary, website_data.business_url)
+
+        await self._apply_privacy_policy(payload, website_data, session_id)
+
+        self._set_thank_you_page_config(payload, summary, website_data.business_url)
+
+        return payload
+
+    async def _get_lead_form_from_llm(
+        self, summary: str, website_url: str
+    ) -> LeadFormPayload:
+        question_mapping_str = "\n".join(
+            f"{q.name.lower()} → {q.value}"
+            for q in QuestionType
+            if q != QuestionType.CUSTOM
+        )
+
+        button_types_str = "\n".join(bt.value for bt in ThankYouPageButtonType)
 
         prompt = LEAD_FORM_PROMPT.format(
-            summary=summary, website_url=website_data.business_url
+            summary=summary,
+            website_url=website_url,
+            question_mapping=question_mapping_str,
+            button_types=button_types_str,
         )
 
         messages = [
@@ -66,8 +97,8 @@ class MetaLeadFormAgent:
             {"role": "user", "content": prompt},
         ]
 
-        payload = None
-        max_retries = 3
+        max_retries = MAX_LLM_RETRIES
+        content = None
 
         for attempt in range(max_retries):
             try:
@@ -82,17 +113,23 @@ class MetaLeadFormAgent:
                 data = json.loads(content)
                 payload = LeadFormPayload.model_validate(data)
 
+                if (
+                    not payload.question_page_custom_headline
+                    or not payload.question_page_custom_headline.strip()
+                ):
+                    payload.question_page_custom_headline = "Share your details"
+
                 if payload.enable_otp_verification:
                     if not payload.is_optimized_for_quality:
                         payload.enable_otp_verification = False
-
                     else:
-                        has_phone = any(q.type == "PHONE" for q in payload.questions)
-
+                        has_phone = any(
+                            q.type == QuestionType.PHONE for q in payload.questions
+                        )
                         if not has_phone:
                             payload.enable_otp_verification = False
 
-                break
+                return payload
 
             except (JSONDecodeError, ValidationError) as e:
                 logger.warning(
@@ -113,21 +150,20 @@ class MetaLeadFormAgent:
                     }
                 )
 
+    def _apply_timestamped_name(
+        self, payload: LeadFormPayload, summary: str, website_url: str
+    ):
         base_name = (payload.name or "").strip()
 
         if not base_name:
-            base_name = self.get_fallback_business_name(
-                summary, website_data.business_url
-            )
+            base_name = self.get_fallback_business_name(summary, website_url)
 
-        base_name = base_name[:25]
-
-        timezone_str = getattr(auth_context, "timezone", "UTC")
+        base_name = base_name[:MAX_BRAND_NAME_LENGTH]
 
         try:
-            tz = ZoneInfo(timezone_str)
-        except Exception:
-            tz = ZoneInfo("UTC")
+            tz = ZoneInfo(auth_context.timezone)
+        except ZoneInfoNotFoundError:
+            tz = ZoneInfo("Asia/Kolkata")
 
         now = datetime.now(tz)
         date_part = now.strftime("%d/%m/%Y")
@@ -135,8 +171,10 @@ class MetaLeadFormAgent:
 
         payload.name = f"{base_name} {date_part} {time_part}"
 
+    async def _apply_privacy_policy(
+        self, payload: LeadFormPayload, website_data, session_id: str
+    ):
         site_links = await self._fetch_site_links(website_data.storage_id)
-
         logger.info("Fetched site links", site_links=site_links)
 
         privacy_link = self._extract_privacy_policy(
@@ -151,24 +189,37 @@ class MetaLeadFormAgent:
                 session_id=session_id,
             )
 
-        normalized_phone = self._normalize_phone(self._extract_phone(summary))
-
-        if normalized_phone:
-            payload.thank_you_page.business_phone_number = normalized_phone
-            payload.thank_you_page.button_type = ThankYouPageButtonType.CALL_BUSINESS
-            payload.thank_you_page.country_code = DEFAULT_COUNTRY_CODE
-
-        else:
-            payload.thank_you_page.button_type = ThankYouPageButtonType.VIEW_WEBSITE
-
-        if payload.thank_you_page.button_type == ThankYouPageButtonType.VIEW_WEBSITE:
-            payload.thank_you_page.website_url = website_data.business_url
+    def _set_thank_you_page_config(
+        self, payload: LeadFormPayload, summary: str, business_url: str
+    ):
+        phone = payload.thank_you_page.business_phone_number
+        if phone:
+            phone = phone.strip()
+        normalized_phone = self._normalize_phone(phone)
 
         if payload.thank_you_page.button_type == ThankYouPageButtonType.CALL_BUSINESS:
-            payload.thank_you_page.button_text = "Call Now"
+            if normalized_phone:
+                payload.thank_you_page.business_phone_number = normalized_phone
+                payload.thank_you_page.country_code = DEFAULT_COUNTRY_CODE
+                payload.thank_you_page.website_url = None
+                payload.thank_you_page.button_text = (
+                    payload.thank_you_page.button_text or "Call Now"
+                )
+            else:
+                logger.warning(
+                    "LLM requested CALL_BUSINESS but phone is missing or invalid. Falling back to VIEW_WEBSITE."
+                )
+                payload.thank_you_page.button_type = ThankYouPageButtonType.VIEW_WEBSITE
+                payload.thank_you_page.website_url = business_url
+                payload.thank_you_page.button_text = "Visit Website"
+                payload.thank_you_page.business_phone_number = None
+                payload.thank_you_page.country_code = None
 
         elif payload.thank_you_page.button_type == ThankYouPageButtonType.VIEW_WEBSITE:
+            payload.thank_you_page.website_url = business_url
             payload.thank_you_page.button_text = "Visit Website"
+            payload.thank_you_page.business_phone_number = None
+            payload.thank_you_page.country_code = None
 
         return payload
 
@@ -176,7 +227,7 @@ class MetaLeadFormAgent:
         self,
         session_id: str,
         payload: LeadFormPayload,
-    ) -> dict:
+    ) -> LeadFormCreateResponse:
 
         if session_id not in sessions:
             raise SessionException(session_id=session_id)
@@ -187,36 +238,17 @@ class MetaLeadFormAgent:
 
         page_id = ad_plan.get("metaPageId") or session.get("metaPageId")
 
-        # TEMP: Hardcoded Meta page ID for development
+        # TODO: Transition from hardcoded fallback to robust error handling or dynamic retrieval.
+        # This ID (332515906622723) is a temporary placeholder for development/testing.
         if not page_id:
             page_id = "332515906622723"
 
-        logger.info("Final Lead Form Name", name=payload.name)
+        enable_otp = payload.enable_otp_verification
+        is_optimized = payload.is_optimized_for_quality
 
-        meta_payload = payload.model_dump(exclude_none=True)
+        is_phone_sms_verify_enabled = enable_otp and is_optimized
 
-        enable_otp = getattr(payload, "enable_otp_verification", False)
-
-        meta_payload["is_optimized_for_quality"] = payload.is_optimized_for_quality
-        meta_payload["is_phone_sms_verify_enabled"] = (
-            bool(enable_otp) and payload.is_optimized_for_quality
-        )
-
-        for field in [
-            "enable_otp_verification",
-            "intent",
-            "is_verification_required",
-            "block_display_for_review",
-        ]:
-            meta_payload.pop(field, None)
-
-        questions = meta_payload.get("questions", [])
-        has_phone = False
-        for q in questions:
-            if isinstance(q, dict) and q.get("type") == "PHONE":
-                has_phone = True
-                q.pop("is_required", None)
-                break
+        has_phone = any(q.type == QuestionType.PHONE for q in payload.questions)
 
         if enable_otp and not has_phone:
             logger.warning(
@@ -227,10 +259,17 @@ class MetaLeadFormAgent:
         logger.info(
             "Creating Meta lead form",
             name=payload.name,
-            is_optimized_for_quality=True,
-            is_phone_sms_verify_enabled=bool(enable_otp),
+            is_optimized_for_quality=is_optimized,
+            is_phone_sms_verify_enabled=is_phone_sms_verify_enabled,
             has_phone_field=has_phone,
+            client_code=auth_context.client_code,
         )
+
+        meta_payload = payload.model_dump(
+            exclude_none=True, exclude={"enable_otp_verification"}
+        )
+
+        meta_payload["is_phone_sms_verify_enabled"] = is_phone_sms_verify_enabled
 
         result = await self.lead_form_adapter.create(
             client_code=auth_context.client_code,
@@ -238,7 +277,7 @@ class MetaLeadFormAgent:
             payload=meta_payload,
         )
 
-        return {"leadFormId": result["id"]}
+        return LeadFormCreateResponse(leadFormId=result["id"])
 
     async def _fetch_site_links(self, storage_id: str):
 
@@ -299,28 +338,20 @@ class MetaLeadFormAgent:
 
         return None
 
-    def _extract_phone(self, text: str) -> str | None:
-        matches = re.findall(r"\+\d[\d\s\-\(\)]{7,15}", text)
-        if matches:
-            return matches[0]
-
-        matches = re.findall(r"\b(?:\d[\s\-\(\)]*){10,12}\b", text)
-        if matches:
-            return max(matches, key=len)
-
-        return None
-
     def _normalize_phone(self, phone: str | None) -> str | None:
         if not phone:
             return None
 
         phone = re.sub(r"[^\d+]", "", phone)
 
-        if phone.startswith("+"):
-            return phone
+        if phone.startswith("+91") and len(phone) == 13:
+            if phone[3] in "6789":
+                return phone
+            return None
 
-        if phone.isdigit() and len(phone[-10:]) == 10:
-            return DEFAULT_PHONE_PREFIX + phone[-10:]
+        digits = re.sub(r"\D", "", phone)
+        if len(digits) == 10 and digits[0] in "6789":
+            return "+91" + digits
 
         return None
 

--- a/api/meta.py
+++ b/api/meta.py
@@ -1,13 +1,11 @@
-from fastapi import APIRouter, Query
-
+from fastapi import APIRouter, Query, Request
+from core.infrastructure.context import auth_context
 from agents.meta import meta_campaign_agent
 from agents.meta.adset_agent import meta_adset_agent
 from utils.response_helpers import success_response
-from core.models.meta import CreateCreativeRequest
 from core.models.lead_form import LeadFormPayload
 from agents.meta.creative_agent import meta_creative_agent
 from agents.meta.lead_form_agent import meta_lead_form_agent
-
 
 
 router = APIRouter(prefix="/api/ds/ads/meta", tags=["meta-ads"])
@@ -37,22 +35,26 @@ async def generate_creative(session_id: str = Query(..., alias="sessionId")):
 @router.post("/creative/image/generate")
 async def generate_creative_image(
     session_id: str = Query(..., alias="sessionId"),
-    ad_account_id: str = Query(..., alias="adAccountId")
+    ad_account_id: str = Query(..., alias="adAccountId"),
 ):
     result = await meta_creative_agent.generate_image(session_id, ad_account_id)
-    return success_response(data=result.model_dump(mode="json"))    
+    return success_response(data=result.model_dump(mode="json"))
 
 
 @router.post("/lead-form/generate")
-async def generate_lead_form(session_id: str = Query(..., alias="sessionId")):
+async def generate_lead_form(
+    request: Request, session_id: str = Query(..., alias="sessionId")
+):
+    timezone_str = request.headers.get("x-timezone", "UTC")
+    auth_context.timezone = timezone_str
+
     result = await meta_lead_form_agent.generate_payload(session_id)
     return success_response(data=result.model_dump(mode="json"))
 
 
 @router.post("/lead-form/create")
 async def create_lead_form(
-    payload: LeadFormPayload,
-    session_id: str = Query(..., alias="sessionId")
+    payload: LeadFormPayload, session_id: str = Query(..., alias="sessionId")
 ):
     result = await meta_lead_form_agent.create_lead_form(session_id, payload)
     return success_response(data=result)

--- a/api/meta.py
+++ b/api/meta.py
@@ -5,8 +5,6 @@ from utils.response_helpers import success_response
 from core.models.lead_form import LeadFormPayload
 from agents.meta.creative_agent import meta_creative_agent
 from core.models.meta import MetaAdCreationRequest
-
-from core.models.lead_form import LeadFormPayload
 from agents.meta.lead_form_agent import meta_lead_form_agent
 from adapters.meta.ad_creation_orchestrator import MetaAdCreationOrchestrator
 

--- a/api/meta.py
+++ b/api/meta.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter, Query, Request
-from core.infrastructure.context import auth_context
+from fastapi import APIRouter, Query
 from agents.meta import meta_campaign_agent
 from agents.meta.adset_agent import meta_adset_agent
 from utils.response_helpers import success_response
@@ -42,12 +41,8 @@ async def generate_creative_image(
 
 
 @router.post("/lead-form/generate")
-async def generate_lead_form(
-    request: Request, session_id: str = Query(..., alias="sessionId")
-):
-    timezone_str = request.headers.get("x-timezone", "UTC")
-    auth_context.timezone = timezone_str
-
+async def generate_lead_form(session_id: str = Query(..., alias="sessionId")):
+    """timezone`: Optional time zone string (e.g., 'Asia/Kolkata'). By default 'Asia/Kolkata' is used."""
     result = await meta_lead_form_agent.generate_payload(session_id)
     return success_response(data=result.model_dump(mode="json"))
 
@@ -57,4 +52,4 @@ async def create_lead_form(
     payload: LeadFormPayload, session_id: str = Query(..., alias="sessionId")
 ):
     result = await meta_lead_form_agent.create_lead_form(session_id, payload)
-    return success_response(data=result)
+    return success_response(data=result.model_dump(mode="json"))

--- a/core/infrastructure/context.py
+++ b/core/infrastructure/context.py
@@ -20,6 +20,7 @@ class AuthContext:
     client_code: str = ""
     x_forwarded_host: str = ""
     x_forwarded_port: str = ""
+    timezone: str = "Asia/Kolkata"
 
 
 _auth_context: ContextVar[AuthContext] = ContextVar(
@@ -32,6 +33,7 @@ def set_auth_context(
     client_code: str = "",
     x_forwarded_host: str = "",
     x_forwarded_port: str = "",
+    timezone: str = "Asia/Kolkata",
 ) -> None:
     """Set auth context for current request. Called by middleware."""
     _auth_context.set(
@@ -40,6 +42,7 @@ def set_auth_context(
             client_code=client_code,
             x_forwarded_host=x_forwarded_host,
             x_forwarded_port=x_forwarded_port,
+            timezone=timezone,
         )
     )
 
@@ -68,6 +71,10 @@ class _AuthContextAccessor:
     @property
     def x_forwarded_port(self) -> str:
         return _auth_context.get().x_forwarded_port
+
+    @property
+    def timezone(self) -> str:
+        return _auth_context.get().timezone
 
 
 auth_context = _AuthContextAccessor()

--- a/core/infrastructure/middleware.py
+++ b/core/infrastructure/middleware.py
@@ -1,4 +1,5 @@
 """FastAPI middleware for setting request context."""
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -16,10 +17,17 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
     """Middleware that populates auth context from request headers."""
 
     async def dispatch(self, request: Request, call_next):
-        set_auth_context(
-            access_token=_extract_token(request),
-            client_code=request.headers.get("clientCode", ""),
-            x_forwarded_host=request.headers.get("x-forwarded-host", ""),
-            x_forwarded_port=request.headers.get("x-forwarded-port", ""),
-        )
+        timezone_header = request.headers.get("x-timezone")
+
+        kwargs = {
+            "access_token": _extract_token(request),
+            "client_code": request.headers.get("clientCode", ""),
+            "x_forwarded_host": request.headers.get("x-forwarded-host", ""),
+            "x_forwarded_port": request.headers.get("x-forwarded-port", ""),
+        }
+
+        if timezone_header:
+            kwargs["timezone"] = timezone_header
+
+        set_auth_context(**kwargs)
         return await call_next(request)

--- a/core/models/lead_form.py
+++ b/core/models/lead_form.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Literal
+from enum import Enum
 from pydantic import BaseModel, Field
 
 
@@ -24,12 +25,17 @@ class PrivacyPolicy(BaseModel):
     url: str
     link_text: str
 
+class ThankYouPageButtonType(str, Enum):
+    VIEW_WEBSITE = "VIEW_WEBSITE"
+    CALL_BUSINESS = "CALL_BUSINESS"
+
+
 
 class ThankYouPage(BaseModel):
     title: str
     body: str
     button_text: str
-    button_type: Literal["VIEW_WEBSITE", "CALL_BUSINESS"]
+    button_type: ThankYouPageButtonType
     website_url: Optional[str] = None
     country_code: Optional[str] = None
     business_phone_number: Optional[str] = None

--- a/core/models/lead_form.py
+++ b/core/models/lead_form.py
@@ -1,40 +1,59 @@
-from typing import List, Optional, Literal
+from typing import Optional
 from enum import Enum
 from pydantic import BaseModel, Field
 
 
-class ContextCard(BaseModel):
-    content: List[str]
-    style: Literal["PARAGRAPH_STYLE", "LIST_STYLE"]
-    title: str = Field(..., max_length=60)
+class ContextCardStyle(str, Enum):
+    PARAGRAPH_STYLE = "PARAGRAPH_STYLE"
+    LIST_STYLE = "LIST_STYLE"
 
 
-class QuestionOption(BaseModel):
-    key: str
-    value: str
+class QuestionType(str, Enum):
+    EMAIL = "EMAIL"
+    PHONE = "PHONE"
+    FULL_NAME = "FULL_NAME"
+    FIRST_NAME = "FIRST_NAME"
+    LAST_NAME = "LAST_NAME"
+    CITY = "CITY"
+    COUNTRY = "COUNTRY"
+    COMPANY_NAME = "COMPANY_NAME"
+    JOB_TITLE = "JOB_TITLE"
+    MARITIAL_STATUS = "MARITIAL_STATUS"
+    CUSTOM = "CUSTOM"
 
-
-class LeadFormQuestion(BaseModel):
-    type: str
-    label: Optional[str] = None
-    key: Optional[str] = None
-    options: Optional[List[QuestionOption]] = None
-
-
-class PrivacyPolicy(BaseModel):
-    url: str
-    link_text: str
 
 class ThankYouPageButtonType(str, Enum):
     VIEW_WEBSITE = "VIEW_WEBSITE"
     CALL_BUSINESS = "CALL_BUSINESS"
 
 
+class ContextCard(BaseModel):
+    title: str = Field(..., min_length=1, max_length=60)
+    content: list[str] = Field(..., min_length=1)
+    style: ContextCardStyle
+
+
+class QuestionOption(BaseModel):
+    key: str = Field(..., min_length=1)
+    value: str = Field(..., min_length=1)
+
+
+class LeadFormQuestion(BaseModel):
+    type: QuestionType
+    label: str | None = Field(None, min_length=1)
+    key: str | None = Field(None, min_length=1)
+    options: list[QuestionOption] | None = None
+
+
+class PrivacyPolicy(BaseModel):
+    url: str = Field(..., min_length=1)
+    link_text: str = Field(..., min_length=1)
+
 
 class ThankYouPage(BaseModel):
-    title: str
-    body: str
-    button_text: str
+    title: str = Field(..., min_length=1, max_length=60)
+    body: str = Field(..., min_length=1)
+    button_text: str = Field(..., min_length=1)
     button_type: ThankYouPageButtonType
     website_url: Optional[str] = None
     country_code: Optional[str] = None
@@ -42,10 +61,11 @@ class ThankYouPage(BaseModel):
 
 
 class LeadFormPayload(BaseModel):
-    name: str = Field(..., max_length=50)
+    name: str = Field(..., min_length=1, max_length=50)
     is_optimized_for_quality: bool
     context_card: ContextCard
-    question_page_custom_headline: str
-    questions: List[LeadFormQuestion]
+    question_page_custom_headline: str = Field(..., min_length=1)
+    questions: list[LeadFormQuestion] = Field(..., min_length=1)
     privacy_policy: PrivacyPolicy
     thank_you_page: ThankYouPage
+    enable_otp_verification: Optional[bool] = False

--- a/core/models/lead_form.py
+++ b/core/models/lead_form.py
@@ -47,7 +47,7 @@ class LeadFormQuestion(BaseModel):
 
 class PrivacyPolicy(BaseModel):
     url: str = Field(..., min_length=1)
-    link_text: str = Field(..., min_length=1)
+    link_text: str = Field(..., min_length=1, max_length=70)
 
 
 class ThankYouPage(BaseModel):
@@ -69,3 +69,7 @@ class LeadFormPayload(BaseModel):
     privacy_policy: PrivacyPolicy
     thank_you_page: ThankYouPage
     enable_otp_verification: Optional[bool] = False
+
+
+class LeadFormCreateResponse(BaseModel):
+    leadFormId: str

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -178,6 +178,27 @@ IMPORTANT:
 
 ---
 
+OTP VERIFICATION LOGIC
+
+- Add field: "enable_otp_verification"
+
+Rules:
+- Only applicable when is_optimized_for_quality = true
+- true → enable OTP
+- false → disable OTP
+
+Enable OTP ONLY for:
+- real estate
+- finance
+- hiring
+- consultation
+- bookings
+
+Otherwise:
+- set enable_otp_verification = false
+
+---
+
 STRICT OUTPUT RULES
 
 - Return ONLY valid JSON
@@ -196,6 +217,7 @@ Return ONLY valid JSON.
 {{
   "name": "",
   "is_optimized_for_quality": false,
+  "enable_otp_verification": false,
   "context_card": {{
     "content": [],
     "style": "",

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -11,6 +11,9 @@ INPUT
 Business Summary:
 {summary}
 
+Website URL:
+{website_url}
+
 ---
 
 TASK
@@ -152,6 +155,13 @@ If CALL_BUSINESS:
 - include:
   - country_code = "IN"
   - business_phone_number
+
+IMPORTANT:
+
+- website_url MUST ALWAYS be exactly: {website_url}
+- DO NOT modify domain
+- DO NOT guess or change TLD (.com, .ai, etc.)
+
 
 ---
 

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -24,7 +24,6 @@ Generate a complete Meta Lead Form payload.
 
 FORM SETTINGS
 
-- name (MAX 50 CHARACTERS)
 - is_optimized_for_quality
 
 Rules:
@@ -90,8 +89,12 @@ city → CITY
 country → COUNTRY  
 company_name → COMPANY_NAME  
 job_title → JOB_TITLE  
-whatsapp_number → WHATSAPP_NUMBER  
 marital_status → MARITIAL_STATUS  
+
+IMPORTANT:
+
+- Do NOT use WHATSAPP_NUMBER as a standard field
+- If WhatsApp number is required, ask it as a CUSTOM SHORT_ANSWER question
 
 ---
 
@@ -137,6 +140,9 @@ Fields required:
 - url → use business website if available
 - link_text → short brand name or "Privacy Policy"
 
+Rules:
+- link_text must be under 70 characters
+
 ---
 
 THANK YOU PAGE
@@ -159,9 +165,9 @@ If VIEW_WEBSITE:
 - include "website_url"
 
 If CALL_BUSINESS:
-- include:
-  - country_code = "IN"
-  - business_phone_number
+- set only button_type = CALL_BUSINESS
+- DO NOT generate business_phone_number
+- DO NOT generate country_code
 
 IMPORTANT:
 

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -31,6 +31,13 @@ Rules:
 - true → HIGHER_INTENT (for consultation, booking, high-value services)
 - false → MORE_VOLUME (for general leads)
 
+
+NAME RULE:
+
+- name must be ONLY the business name
+- extract exact brand name from summary
+- keep it under 25 characters
+
 ---
 
 CONTEXT CARD

--- a/prompts/meta/lead_form.txt
+++ b/prompts/meta/lead_form.txt
@@ -26,16 +26,61 @@ FORM SETTINGS
 
 - is_optimized_for_quality
 
+
+INTENT DETECTION (STRICT)
+
+Analyze the summary and classify user intent based on signals.
+
+HIGH INTENT (MUST use CALL_BUSINESS and is_optimized_for_quality = true):
+- Explicit contact instructions (call, contact us, book now, schedule visit)
+- Phone number present AND used for inquiries
+- Actions like:
+  - site visit
+  - consultation
+  - admission inquiry
+  - booking/demo
+
+MEDIUM INTENT:
+- Phone present but not strongly emphasized
+- Some inquiry signals but also informational content
+
+LOW INTENT (MUST use VIEW_WEBSITE and is_optimized_for_quality = false):
+- Pure informational content
+- Branding or awareness
+- No strong call-to-action
+
 Rules:
-- true → HIGHER_INTENT (for consultation, booking, high-value services)
+- true → HIGHER_INTENT (for consultation, booking, high-value services, real estate, finance, hiring)
 - false → MORE_VOLUME (for general leads)
+
+
+DECISION PRIORITY (STRICT ORDER)
+
+Follow this order when making decisions:
+
+1. PHONE SIGNAL RULE (highest priority)
+2. INTENT DETECTION
+3. CTA DECISION RULES
+4. CONSISTENCY RULE
+
+If conflicts occur:
+→ Follow the higher priority rule
 
 
 NAME RULE:
 
 - name must be ONLY the business name
-- extract exact brand name from summary
-- keep it under 25 characters
+- Extract the business name EXACTLY as it appears in the summary
+- DO NOT modify, rephrase, or invent words
+- DO NOT add extra words like "Project", "Official", "Pvt Ltd" unless already present
+
+- If the name exceeds 25 characters:
+  → truncate safely without changing meaning
+  → DO NOT break words mid-way
+
+- If no clear business name is found:
+  → extract from website domain (if available)
+  → otherwise use a short meaningful fallback
 
 ---
 
@@ -63,6 +108,7 @@ IMPORTANT:
 - Prefer phrases over full sentences
 - DO NOT exceed 80 characters under any condition
 - If any bullet exceeds 80 characters, rewrite it to fit within limit
+- Do NOT invent features or benefits not mentioned in the summary
 
 ---
 
@@ -80,16 +126,7 @@ Types:
 
 Supported keys:
 
-email → EMAIL  
-phone_number → PHONE  
-full_name → FULL_NAME  
-first_name → FIRST_NAME  
-last_name → LAST_NAME  
-city → CITY  
-country → COUNTRY  
-company_name → COMPANY_NAME  
-job_title → JOB_TITLE  
-marital_status → MARITIAL_STATUS  
+{question_mapping}
 
 IMPORTANT:
 
@@ -123,13 +160,95 @@ Rules:
 - MULTIPLE_CHOICE must have 2–5 options
 - option keys must be lowercase, no special characters
 
+QUESTION GENERATION RULES (CRITICAL)
+
+Questions must be generated dynamically based on the business context.
+
+DO NOT copy templates.
+DO NOT generate generic questions.
+
+Instead, analyze:
+- What is the user trying to achieve?
+- What information helps qualify serious leads?
+- What helps the business take action?
+
+QUALITY RULES (STRICT)
+
+- Questions MUST be specific and meaningful
+- Questions MUST NOT be vague or generic
+
+Avoid:
+- "Any preferences?"
+- "Tell us more"
+- "Your requirement?"
+
+QUALIFICATION RULE
+
+- At least ONE question MUST identify:
+  - serious vs casual users
+  - intent level
+
+GUIDELINES (FLEXIBLE, NOT HARD CODED)
+
+For high-consideration businesses:
+- Ask about budget, timeline, or intent (visit, booking)
+
+For services:
+- Ask about requirement type or urgency
+
+For low-intent:
+- Ask about interest or category
+
+FINAL CHECK
+
+- Every question must have a purpose
+- Remove redundant or useless questions
+- Do NOT assume information not present in the summary
+
+EXAMPLES OF HIGH-QUALITY QUESTIONS (FOR GUIDANCE ONLY)
+
+- "What is your budget range?"
+- "When would you like to schedule a visit?"
+- "Which service are you interested in?"
+- "What is your preferred timeline?"
+
+IMPORTANT:
+- Do NOT copy these directly
+- Use them to understand specificity and intent
+
 ---
 
 QUESTION PAGE HEADLINE
 
-Always include:
+Generate a dynamic headline based on the business type and intent.
 
-"question_page_custom_headline": "Please enter the below Details."
+Rules:
+- Maximum 60 characters (HARD LIMIT)
+- Must feel like a natural next step after the context card
+- Must be relevant to the business and user intent
+- Should guide the user on what to do next
+- Avoid generic phrases like:
+  - "Please enter the below details"
+  - "Fill the form below"
+
+Guidelines by intent:
+
+HIGH INTENT (consultation, booking, real estate, education):
+- "Share your details to schedule a visit"
+- "Let our expert connect with you"
+- "Tell us your requirements to get started"
+
+MEDIUM INTENT:
+- "Help us understand your needs"
+- "Tell us a bit about your requirement"
+
+LOW INTENT (exploration, browsing):
+- "Get more details about this offer"
+- "Explore more with your details"
+
+IMPORTANT:
+- Do NOT copy examples
+- Generate a fresh, relevant headline every time
 
 ---
 
@@ -156,17 +275,127 @@ Fields required:
 
 button_type must be one of:
 
-VIEW_WEBSITE  
-CALL_BUSINESS  
+{button_types}
 
-Rules:
+---
+
+CTA DECISION RULES (STRICT)
+
+- If the business requires direct human interaction (consultation, booking, service, real estate, finance, hiring):
+  → MUST use CALL_BUSINESS
+
+- If the goal is to drive users to explore products, browse offerings, or visit a website:
+  → MUST use VIEW_WEBSITE
+
+- DO NOT randomly choose button_type
+- button_type MUST align with business intent from summary
+
+
+PHONE SIGNAL RULE (CRITICAL)
+
+- If a valid phone number is present AND strong contact intent is clearly indicated:
+  → MUST treat as HIGH INTENT
+  → MUST use CALL_BUSINESS
+
+- Do NOT ignore phone numbers
+- Do NOT default to VIEW_WEBSITE when contact intent exists
+
+
+FALLBACK RULE (IMPORTANT)
+
+- If CALL_BUSINESS is selected but no valid phone number exists:
+  → Switch to VIEW_WEBSITE
+  → DO NOT keep CALL_BUSINESS without a phone number
+
+
+MULTIPLE PHONE RULE
+
+- If multiple valid phone numbers exist:
+  → Select ONLY ONE number
+  → Prefer the first valid mobile number
+  → Do NOT return multiple numbers
+
+
+---
+
+OPTIMIZATION-CTA ALIGNMENT RULE
+
+- If is_optimized_for_quality = true:
+  → Must use CALL_BUSINESS
+
+- If is_optimized_for_quality = false:
+  → Must use VIEW_WEBSITE
+
+---
+
+PHONE NUMBER RULES (STRICT - INDIA FOCUS)
+
+- If button_type = CALL_BUSINESS:
+  → Populate "business_phone_number" using ONLY a valid mobile number from the summary
+
+- Accept ONLY:
+  - 10-digit Indian mobile numbers starting with 6, 7, 8, or 9
+  - OR +91 format with exactly 10 digits after +91
+
+- DO NOT use:
+  - landline numbers
+  - toll-free numbers (1800, 800, etc.)
+  - short codes or extensions
+
+- If no valid mobile number exists:
+  → leave "business_phone_number" empty
+
+PHONE NUMBER INTEGRITY RULE (CRITICAL)
+
+- NEVER generate or guess phone numbers
+- NEVER modify digits of a phone number
+- ONLY return phone numbers EXACTLY as present in the summary
+- You may remove spaces or formatting, but digits MUST remain identical
+- If no valid number exists → return null
+
+
+---
+
+THANK YOU PAGE CONTENT RULES
+
+- title: Must be action-oriented and relevant to the business
+- body: Must clearly explain next step in 1–2 short sentences
+- Avoid generic text like "Thank you for your interest"
+
+Examples:
+
+For CALL_BUSINESS:
+- "Our expert will contact you shortly"
+- "Connect with our team now"
+
+For VIEW_WEBSITE:
+- "Explore more on our website"
+- "Discover our latest offerings"
+
+---
+
+BUTTON TEXT RULES
+
+- CALL_BUSINESS → "Call Now", "Talk to Expert", "Speak with Us"
+- VIEW_WEBSITE → "Visit Website", "Explore Now", "Learn More"
+
+---
+
+CONSISTENCY RULE
+
+- button_text, title, and body MUST align with button_type
+- If button_type = CALL_BUSINESS → content must encourage calling
+- If button_type = VIEW_WEBSITE → content must encourage visiting website
+
+---
+
+FIELD RULES
 
 If VIEW_WEBSITE:
 - include "website_url"
 
 If CALL_BUSINESS:
-- set only button_type = CALL_BUSINESS
-- DO NOT generate business_phone_number
+- MUST include "business_phone_number" if a valid mobile number exists
 - DO NOT generate country_code
 
 IMPORTANT:
@@ -183,19 +412,46 @@ OTP VERIFICATION LOGIC
 - Add field: "enable_otp_verification"
 
 Rules:
-- Only applicable when is_optimized_for_quality = true
-- true → enable OTP
-- false → disable OTP
 
-Enable OTP ONLY for:
-- real estate
-- finance
-- hiring
-- consultation
-- bookings
+- Enable OTP ONLY when:
+  - is_optimized_for_quality = true AND
+  - the intent involves serious user commitment
 
-Otherwise:
-- set enable_otp_verification = false
+SERIOUS INTENT INCLUDES:
+- property inquiries (real estate)
+- consultations (legal, medical, financial)
+- bookings or appointments
+- admissions or enrollment inquiries
+- hiring or job applications
+- any scenario where direct contact or follow-up is expected
+
+- Disable OTP when:
+  - intent is informational or exploratory
+  - user is likely browsing or comparing options
+
+CRITICAL RULE:
+
+- OTP MUST NOT be enabled for low-intent or awareness flows
+- OTP MUST align with intent, NOT just industry
+
+FINAL OUTPUT:
+
+- If conditions match → "enable_otp_verification": true
+- Otherwise → "enable_otp_verification": false
+
+---
+
+
+FINAL OUTPUT VALIDATION (CRITICAL)
+
+Before returning JSON:
+
+- Ensure button_type and button_text match
+- Ensure no conflicting fields:
+  - CALL_BUSINESS → no website_url
+  - VIEW_WEBSITE → no phone number
+- Ensure all required fields are correct
+- Remove any conflicting values
 
 ---
 
@@ -223,7 +479,7 @@ Return ONLY valid JSON.
     "style": "",
     "title": ""
   }},
-  "question_page_custom_headline": "Please enter the below Details.",
+  "question_page_custom_headline": "",
   "questions": [],
   "privacy_policy": {{
     "url": "",


### PR DESCRIPTION
Pass website_url to the LLM prompt and update the prompt to require the exact website URL. Parse LLM output via json.loads and use LeadFormPayload.model_validate (pydantic v2), trimming and sanitizing the form name before validation. Improve phone extraction and normalization: use broader regexes, prefer the longest match, normalize numbers to +91 (preserving +91-prefixed values), and return None for unparseable values. Update thank-you button logic to set CALL_BUSINESS with country_code IN when a phone is present, otherwise set VIEW_WEBSITE and populate website_url. Misc: import json, tighten whitespace normalization for form names, and improve error logging for invalid LLM output.