### PR TITLE
Meta: rename special category & add LLM response

### DIFF
--- a/agents/meta/README.md
+++ b/agents/meta/README.md
@@ -149,7 +149,7 @@ POST /api/ds/ads/meta/campaign/create
 ### Special Ad Categories
 - `HOUSING`
 - `EMPLOYMENT`
-- `CREDIT`
+- `FINANCIAL_PRODUCTS_SERVICES`
 - `ISSUES_ELECTIONS_POLITICS`
 - `NONE`
 

--- a/agents/meta/adset_agent.py
+++ b/agents/meta/adset_agent.py
@@ -2,7 +2,12 @@ import asyncio
 import structlog
 
 from adapters.meta.adsets import MetaAdSetAdapter
-from core.models.meta import LLMAdSetTargeting, CreateAdSetRequest, DetailedTargeting
+from core.models.meta import (
+    LLMAdSetTargeting,
+    CreateAdSetRequest,
+    DetailedTargeting,
+    LLMAdSetGenerationResponse,
+)
 from agents.shared.llm import chat_completion
 from core.infrastructure.context import auth_context
 from exceptions.custom_exceptions import (
@@ -30,7 +35,9 @@ class MetaAdSetAgent:
         self.targeting_adapter = MetaDetailedTargetingAdapter()
         self.geo_targeting_adapter = MetaGeoTargetingAdapter()
 
-    async def generate_payload(self, session_id: str, ad_account_id: str) -> dict:
+    async def generate_payload(
+        self, session_id: str, ad_account_id: str
+    ) -> LLMAdSetGenerationResponse:
         website_data = await self.business_service.fetch_website_data(session_id)
 
         logger.info(
@@ -104,14 +111,14 @@ class MetaAdSetAgent:
             allowed_countries=allowed_countries,
         )
 
-        return {
-            "genders": targeting.genders,
-            "age_min": targeting.age_min,
-            "age_max": targeting.age_max,
-            "locales": locales,
-            "flexible_spec": flexible_spec,
-            "locations": locations,
-        }
+        return LLMAdSetGenerationResponse(
+            genders=targeting.genders,
+            age_min=targeting.age_min,
+            age_max=targeting.age_max,
+            locales=locales,
+            flexible_spec=flexible_spec,
+            locations=locations,
+        )
 
     # TODO: wire to API route when adset creation endpoint is added
     async def create_adset(

--- a/agents/meta/campaign_agent.py
+++ b/agents/meta/campaign_agent.py
@@ -1,9 +1,8 @@
-from datetime import datetime
 import structlog
 from pydantic import ValidationError
 
 from adapters.meta import MetaCampaignAdapter
-from core.models.meta import CampaignPayload, CreateCampaignRequest
+from core.models.meta import CampaignPayload, CreateCampaignRequest, SpecialAdCategory
 from agents.shared.llm import chat_completion
 from core.infrastructure.context import auth_context
 from exceptions.custom_exceptions import AIProcessingException
@@ -36,8 +35,15 @@ class MetaCampaignAgent:
 
     async def _generate_payload_from_llm(self, summary: str) -> CampaignPayload:
         """Generate campaign payload using LLM."""
+
+        special_ad_categories_str = "\n".join(
+            f"  - `{c.value}`" for c in SpecialAdCategory
+        )
+
         template = load_prompt("meta/campaign.txt")
-        prompt = template.format(summary=summary)
+        prompt = template.format(
+            summary=summary, special_ad_categories=special_ad_categories_str
+        )
 
         messages = [
             {"role": "system", "content": "Respond only with valid JSON"},
@@ -52,7 +58,6 @@ class MetaCampaignAgent:
 
         try:
             payload = CampaignPayload.model_validate_json(content)
-            payload.name = f"{payload.name} - {datetime.now().strftime('%Y-%m-%d')}"
             return payload
         except ValidationError as e:
             logger.error("Failed to parse LLM output", error=str(e), raw=content)

--- a/core/models/meta.py
+++ b/core/models/meta.py
@@ -20,7 +20,7 @@ class CampaignObjective(str, Enum):
 class SpecialAdCategory(str, Enum):
     HOUSING = "HOUSING"
     EMPLOYMENT = "EMPLOYMENT"
-    CREDIT = "CREDIT"
+    FINANCIAL_PRODUCTS_SERVICES = "FINANCIAL_PRODUCTS_SERVICES"
     ISSUES_ELECTIONS_POLITICS = "ISSUES_ELECTIONS_POLITICS"
     NONE = "NONE"
 
@@ -220,11 +220,21 @@ CreativePayload = Annotated[
 
 
 class CampaignPayload(BaseModel):
-    name: str = Field(..., min_length=1)
-    objective: CampaignObjective
-    status: Status
-    special_ad_categories: list[SpecialAdCategory] | None = None
-    special_ad_category_country: list[CountryCode] | None = None
+    name: str = Field(default="campaign")
+    objective: CampaignObjective = Field(default=CampaignObjective.OUTCOME_LEADS)
+    status: Status = Field(default=Status.PAUSED)
+    special_ad_categories: list[SpecialAdCategory] | None = Field(default=None)
+    special_ad_category_country: list[CountryCode] | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_special_ad_category_country(self):
+        if (
+            self.special_ad_categories
+            and SpecialAdCategory.NONE in self.special_ad_categories
+        ):
+            self.special_ad_categories = [SpecialAdCategory.NONE]
+            self.special_ad_category_country = []
+        return self
 
 
 class CreateCampaignRequest(BaseModel):
@@ -300,7 +310,7 @@ class ExistingIdsPayload(BaseModel):
 
 class AdPayload(BaseModel):
     name: str = Field(..., min_length=1)
-    status: Status
+    status: Status = Status.PAUSED
     adset_id: str | None = None
     creative: dict[str, Annotated[str, Field(min_length=1)]] | None = (
         None  # creative_id: str
@@ -327,7 +337,7 @@ class Schedule(BaseModel):
                     return datetime.fromisoformat(value).date()
                 except Exception:
                     raise ValueError("Date must be in format dd/mm/yyyy or YYYY-MM-DD")
- 
+
         return value
 
     @model_validator(mode="after")
@@ -505,7 +515,7 @@ class PromotedObject(BaseModel):
 
 class AdSetPayload(BaseModel):
     name: str = Field(..., min_length=1)
-    status: Status
+    status: Status = Status.PAUSED
     schedule: Schedule | None = None
     targeting: Targeting
     destination_type: DestinationType
@@ -617,14 +627,27 @@ class AssembledMetaPayloads(BaseModel):
 
 class MetaAdCreationRequest(BaseModel):
     """Unified request model for creating a full Meta Ad structure."""
+
     ad_account_id: str = Field(..., min_length=1)
     campaign: CampaignPayload
     adset: AdSetPayload
     creative: CreativePayload
     ad: AdPayload
     existing_ids: ExistingIdsPayload | None = None
- 
- 
+
+
 class MetaAdCreationResponse(BaseModel):
     """Unified response model containing the final state of all created/recovered IDs."""
+
     ids: ExistingIdsPayload
+
+
+class LLMAdSetGenerationResponse(BaseModel):
+    """Result model for the adset generation agent."""
+
+    genders: list[Gender]
+    age_min: int = Field(..., ge=meta_constants.MIN_AGE, le=meta_constants.MAX_AGE)
+    age_max: int = Field(..., ge=meta_constants.MIN_AGE, le=meta_constants.MAX_AGE)
+    locales: list[dict]
+    flexible_spec: list[dict]
+    locations: dict | None = None

--- a/exceptions/__init__.py
+++ b/exceptions/__init__.py
@@ -1,0 +1,1 @@
+# Exceptions package

--- a/prompts/meta/campaign.txt
+++ b/prompts/meta/campaign.txt
@@ -1,7 +1,6 @@
 You are a Meta Ads Campaign specialist.
 
-Your role is to generate a valid Meta Ads **Campaign payload** based on the provided input.
-This payload will be used directly with the Meta Marketing API.
+Your role is to generate a valid Meta Ads Campaign payload based on the provided input.
 
 ---
 
@@ -9,77 +8,99 @@ This payload will be used directly with the Meta Marketing API.
 
 You will receive:
 
-- **Summary**: A natural language description of the business, campaign goal, and intent.
-
-Input placeholder:
 - Summary: {summary}
 
 ---
 
 ## Task
 
-Based on the Summary, generate a **Meta Campaign payload only** with the following fields:
+Generate ONLY the following fields:
 
-- `name`
-- `objective`
-- `special_ad_categories`
-- `special_ad_category_country`
-
----
-
-## Objective Rules
-
-- The `objective` must be selected strictly from the following allowed values:
-  - `OUTCOME_LEADS`
-  - `OUTCOME_TRAFFIC`
-  - `OUTCOME_AWARENESS`
-
-- Choose the most appropriate objective based on the campaign intent inferred from the Summary.
+- special_ad_categories
+- special_ad_category_country
 
 ---
 
 ## Special Ad Category Rules
 
-- Analyze the Summary to determine whether the campaign falls under any special ad category.
 - Allowed values:
-  - `HOUSING`
-  - `EMPLOYMENT`
-  - `CREDIT`
-  - `ISSUES_ELECTIONS_POLITICS`
-  - `NONE`
+{special_ad_categories}
 
-- If no special ad category applies, return:
-  - `["NONE"]`
+- You MUST only use values from the allowed list. Do not invent new values.
+
+- If no special ad category applies:
+  - special_ad_categories = ["NONE"]
+  - special_ad_category_country = []
+
+- If "NONE" is selected:
+  - It MUST be the only value in the list
+  - special_ad_category_country MUST be empty []
+
+- Do NOT mix "NONE" with any other category.
+
+---
+
+## Category Detection Guidelines
+
+Use the following signals to determine the correct category.
+The examples are illustrative, not exhaustive. Use semantic meaning from the summary.
+
+1. EMPLOYMENT
+- Job listings, hiring, careers, recruitment, vacancies
+- Examples: "We are hiring", "Apply for jobs", "Career opportunities"
+
+2. HOUSING
+- Real estate, property sales/rentals, apartments, homes
+- Examples: "Buy a house", "Flats for sale", "Rental properties"
+
+3. FINANCIAL_PRODUCTS_SERVICES
+- Loans, credit cards, insurance, banking, investments, EMI, finance offers
+- Examples: "Apply for loan", "Get credit card", "Investment plan"
+
+4. ISSUES_ELECTIONS_POLITICS
+- Political campaigns, public policy, elections, political parties, government messaging
+- Examples: "Vote for candidate", "Government policy awareness", "Political campaign"
+
+5. NONE
+- Any normal business that does not fall into the above categories
+- Examples: restaurants, e-commerce, education, SaaS, gyms, etc.
+
+---
+
+## Decision Rules
+
+- Choose ONLY one category unless clearly multiple apply
+- If unsure, default to ["NONE"]
+- Be conservative: do NOT over-classify
+- Do NOT assume political category unless explicitly clear
 
 ---
 
 ## Country Rules
 
-- Determine the relevant country or countries for `special_ad_category_country` by:
-  - Explicit country mentions in the Summary, or
-  - Implicit business location if clearly inferred
+- If special_ad_categories is NOT ["NONE"]:
+  - special_ad_category_country MUST contain at least one valid country
 
-- Use **ISO-2 country codes only** (example: `IN`, `US`, `GB`).
+- Use ONLY ISO-2 country codes (e.g., IN, US, GB, FR)
+- Do NOT use regions like EU, APAC, GLOBAL
 
----
-
-## Naming Rules
-
-- The campaign `name` should be concise and meaningful.
-- Include the **business name** and **campaign intent or goal** when possible.
+- If country cannot be determined from the summary:
+  - Return an empty array []
 
 ---
 
 ## Output Rules
 
-- Return **only valid JSON**
-- Do not include explanations, comments, or formatting text
-- Do not include ad sets, targeting, creatives, or budget
-- The output must match the following structure exactly:
+- Return ONLY valid JSON
+- No explanation, no extra text
+- Do not include any other fields
+- Return raw JSON only — no markdown, no code fences, no backticks
+
+---
+
+## Output Format
 
 {{
-  "name": "",
-  "objective": "",
   "special_ad_categories": [],
   "special_ad_category_country": []
 }}

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+# Services package

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils package


### PR DESCRIPTION
Refactored Meta campaign and adset flow to improve consistency and type safety. Replaced CREDIT with FINANCIAL_PRODUCTS_SERVICES across models, prompt, and docs. Added typed response for adset generation and introduced defaults and validation in CampaignPayload (including handling for NONE category). Simplified campaign prompt with stricter rules and JSON-only output. Also set default PAUSED status for adset and ad payloads.