### PR TITLE
feat: bridge adzump session into ds + chatv2 enhancements

### DIFF
--- a/agents/chatv2/chat_agent.py
+++ b/agents/chatv2/chat_agent.py
@@ -21,16 +21,6 @@ from exceptions.custom_exceptions import SessionException
 
 logger = get_logger(__name__)
 
-STATUS_PROGRESS = {
-    ChatStatus.IN_PROGRESS: "1/3",
-    ChatStatus.CONFIRMING_LOCATION: "1/3",
-    ChatStatus.SELECTING_PARENT_ACCOUNT: "2/3",
-    ChatStatus.SELECTING_ACCOUNT: "2/3",
-    ChatStatus.AWAITING_CONFIRMATION: "3/3",
-    ChatStatus.COMPLETED: "3/3",
-}
-
-
 class ChatV2Agent:
     """Application agent for chat operations using LangGraph state machine."""
 
@@ -46,30 +36,20 @@ class ChatV2Agent:
             self._graph = get_chat_graph()
         return self._graph
 
-    async def start_session(self) -> dict:
-        """Create a new chat session with initialized state."""
-        session_id = self._session_store.create()
-
-        chat_state: ChatState = create_initial_state()
-        self._session_store.update(session_id, chat_state)
-
-        logger.info("New chatv2 session started", session_id=session_id)
-        return {
-            "session_id": session_id,
-            "message": (
-                "Hi! I'll help you set up a Google Ads or Meta campaign. "
-                "First, which platform would you like to advertise on \u2014 Google or Meta?"
-            ),
-        }
-
     async def process_message_stream(
-        self, session_id: str, message: str
+        self, session_id: str | None, message: str
     ) -> AsyncIterator[StreamEvent]:
         """Stream chat processing as SSE events.
 
+        If session_id is None, creates a new session and emits session_init.
         Three phases: drain pre-buffered → merged fan-in → finalize.
         """
+        if not session_id:
+            session_id = self._create_session()
+            yield data_event("session_init", {"session_id": session_id})
+
         state = self._session_store.get(session_id)
+        self._session_store.clear_cancelled(session_id)
 
         competitor_names = _try_parse_competitor_selection(message)
         if competitor_names is not None:
@@ -81,25 +61,24 @@ class ChatV2Agent:
             yield data_event("field_update", {"field": "competitors", "value": competitor_names})
             yield progress_event(node="competitors", phase="end", message=f"{len(competitor_names)} competitor(s) saved")
             confirmation = f"Got it! {len(competitor_names)} competitor(s) saved."
-            previous_question = state.get("response_message", "")
-            if previous_question:
-                confirmation += f"\n\n{previous_question}"
-            yield done_event(
-                status=state.get("status", "in_progress"),
-                reply=confirmation,
-                collected_data=self._get_trackable_fields(ad_plan),
-                progress=self._get_progress(
-                    ChatStatus.from_string(state.get("status", "in_progress"))
-                ),
-                account_selection=state.get("account_selection"),
-            )
+
+            # Re-build full response now that competitors are confirmed.
+            # The summary was held back before — now it should show.
+            response = self._build_response(state)
+            response.intermediate_messages = [{
+                "reply": confirmation,
+                "attachments": [{"type": "confirmed_competitors", "competitors": competitor_names}],
+            }]
+            yield done_event(**response.model_dump())
             return
 
         state["messages"] = list(state.get("messages", [])) + [
             HumanMessage(content=message)
         ]
+        state["message_attachments"] = [{"__clear__": True}]
+        state["intermediate_messages"] = [{"__clear__": True}]
 
-        for event in self._drain_buffered_scrape_events(session_id, state):
+        for event in self._drain_buffered_scrape_events(session_id, state, replay_history=True):
             yield event
 
         config = {"configurable": {"thread_id": session_id}}
@@ -131,7 +110,6 @@ class ChatV2Agent:
         return SessionResponse(
             status=status.value,
             data=payload,
-            progress=self._get_progress(status),
             last_activity=last_activity.isoformat() if last_activity else None,
         )
 
@@ -144,6 +122,11 @@ class ChatV2Agent:
         self._session_store.delete(session_id)
         logger.info("Chatv2 session ended", session_id=session_id)
         return {"message": f"Session {session_id} ended successfully."}
+
+    def cancel(self, session_id: str) -> None:
+        """Mark session for cancellation."""
+        self._session_store.mark_cancelled(session_id)
+        logger.info("Session marked for cancellation", session_id=session_id)
 
     def validate_session(self, session_id: str) -> None:
         """Raise SessionException if session is missing or completed."""
@@ -158,13 +141,19 @@ class ChatV2Agent:
     async def _stream_graph_and_scrape(
         self, state: dict, config: dict, session_id: str
     ) -> AsyncIterator[StreamEvent]:
-        """Run graph + scrape as concurrent producers, yield interleaved events."""
+        """Run graph + scrape as concurrent producers, yield interleaved events.
+
+        Returns as soon as the graph producer finishes (sentinel received).
+        The scrape producer is cancelled — remaining scrape progress is picked
+        up later via _emit_completion_and_remaining_scrape.
+        """
         event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
+        graph_done = False
 
         async def graph_producer() -> None:
             try:
                 async for mode, chunk in self.graph.astream(
-                    state, config=config, stream_mode=["custom", "messages"]
+                    state, config=config, stream_mode=["custom", "messages", "updates"]
                 ):
                     for event in translate_stream_chunk(mode, chunk):
                         await event_queue.put(event)
@@ -173,26 +162,41 @@ class ChatV2Agent:
 
         async def scrape_producer() -> None:
             try:
-                async for step, phase, msg in self._scrape_tasks.subscribe_progress(session_id):
+                async for step, phase, msg in self._scrape_tasks.subscribe_progress(
+                    session_id, wait_for_job=True
+                ):
                     await event_queue.put(_build_scrape_event(step, phase, msg))
             finally:
                 await event_queue.put(None)
 
-        producers = [asyncio.create_task(graph_producer())]
-        if self._scrape_tasks.has_active_scrape(session_id):
-            producers.append(asyncio.create_task(scrape_producer()))
+        graph_task = asyncio.create_task(graph_producer())
+        scrape_task = asyncio.create_task(scrape_producer())
 
-        sentinels = 0
-        while sentinels < len(producers):
+        while True:
             item = await event_queue.get()
             if item is None:
-                sentinels += 1
-                continue
-            yield item
+                if not graph_done:
+                    # First sentinel — check if it's the graph that finished
+                    if graph_task.done():
+                        graph_done = True
+                        break
+                    # Scrape finished first; keep waiting for graph
+                    continue
+            else:
+                # Check for cancellation before yielding
+                if self._session_store.is_cancelled(session_id):
+                    graph_task.cancel()
+                    if not scrape_task.done():
+                        scrape_task.cancel()
+                    self._session_store.clear_cancelled(session_id)
+                    yield done_event(status="cancelled", reply="Operation cancelled.")
+                    return
+                yield item
 
-        for p in producers:
-            if not p.done():
-                p.cancel()
+        # Graph is done — cancel scrape producer so we don't block on it.
+        # Remaining scrape progress is streamed after the done_event.
+        if not scrape_task.done():
+            scrape_task.cancel()
 
     async def _emit_completion_and_remaining_scrape(
         self, config: dict, session_id: str
@@ -207,42 +211,90 @@ class ChatV2Agent:
 
         self._session_store.update(session_id, final_state)
 
-        if self._scrape_tasks.has_active_scrape(session_id):
-            async for step, phase, msg in self._scrape_tasks.subscribe_progress(session_id):
-                yield _build_scrape_event(step, phase, msg)
-
+        # Emit done_event FIRST to unblock the user's input immediately.
+        # Scrape progress events stream after — frontend handles them in the sidebar.
         buffered = self._drain_buffered_scrape_events(session_id, final_state)
 
         yield done_event(**self._build_response(final_state).model_dump())
 
         for event in buffered:
             yield event
+
+        if self._scrape_tasks.has_active_scrape(session_id):
+            partial_emitted = False
+            async for step, phase, msg in self._scrape_tasks.subscribe_progress(session_id):
+                yield _build_scrape_event(step, phase, msg)
+                # Emit partial summary as soon as it becomes available
+                if not partial_emitted:
+                    partial = self._scrape_tasks.get_partial_summary(session_id)
+                    if partial:
+                        partial_emitted = True
+                        yield data_event("website_summary", {
+                            "summary": partial.get("summary", ""),
+                            "business_url": final_state.get("ad_plan", {}).get("websiteURL", ""),
+                            "partial": True,
+                        })
+            # Re-drain after scrape finishes to pick up the final result
+            for event in self._drain_buffered_scrape_events(session_id, final_state):
+                yield event
+
+            # Emit analysis_complete so frontend can render a chat-visible summary card
+            ad_plan = final_state.get("ad_plan", {})
+            ws = ad_plan.get("websiteSummary")
+            if isinstance(ws, dict) and "error" not in ws:
+                yield data_event("analysis_complete", {
+                    "business_name": ws.get("business_type", ""),
+                    "summary": (ws.get("summary") or "")[:300],
+                    "location": ws.get("location"),
+                    "products": (ws.get("products_services") or [])[:5],
+                })
+
         self._session_store.update(session_id, final_state)
 
     # Private helpers
+
+    def _create_session(self) -> str:
+        """Create a new chat session with initialized state. Returns session_id."""
+        session_id = self._session_store.create()
+        self._session_store.update(session_id, create_initial_state())
+        logger.info("New chatv2 session started", session_id=session_id)
+        return session_id
 
     def _build_response(self, state: ChatState) -> ChatResponse:
         status = ChatStatus.from_string(state.get("status", "in_progress"))
         ad_plan = state.get("ad_plan", {})
         payload = self._get_trackable_fields(ad_plan)
 
+        account_selection = state.get("account_selection")
+        location_selection = state.get("location_selection")
+        reply = state.get("response_message", "")
+
+        # Priority: location → competitors → accounts → summary.
+        # Hold back lower-priority UI when a higher-priority picker should show first.
         competitors_pending = (
             "suggested_competitors" in ad_plan
             and "competitors" not in ad_plan
             and ad_plan.get("suggested_competitors")
         )
+        if account_selection and (location_selection or competitors_pending):
+            account_selection = None
+            if competitors_pending:
+                reply = "Please review and select the competitors you'd like to target."
+
+        # Hold back summary when competitors haven't been confirmed yet
+        if competitors_pending and status == ChatStatus.AWAITING_CONFIRMATION:
+            reply = "Please review and select the competitors you'd like to target."
+            status = ChatStatus.SELECTING_ACCOUNT  # keep status pre-confirmation
 
         return ChatResponse(
             status=status.value,
-            reply=state.get("response_message", ""),
+            reply=reply,
             collected_data=payload,
-            progress=self._get_progress(status),
-            account_selection=None if competitors_pending else state.get("account_selection"),
+            account_selection=account_selection,
             location_selection=state.get("location_selection"),
+            message_attachments=state.get("message_attachments", []),
+            intermediate_messages=state.get("intermediate_messages", []),
         )
-
-    def _get_progress(self, status: ChatStatus) -> str:
-        return STATUS_PROGRESS.get(status, "1/3")
 
     def _get_trackable_fields(self, ad_plan: dict) -> dict:
         return {
@@ -252,10 +304,18 @@ class ChatV2Agent:
         }
 
     def _drain_buffered_scrape_events(
-        self, session_id: str, state: dict
+        self, session_id: str, state: dict, *, replay_history: bool = False
     ) -> list[StreamEvent]:
-        """Drain queued scrape progress and merge final result if ready."""
+        """Drain queued scrape progress and merge final result if ready.
+
+        When *replay_history* is True, emit the full progress history first
+        so the frontend can rebuild all scrape steps after an SSE reconnect.
+        """
         events: list[StreamEvent] = []
+
+        if replay_history:
+            for step, phase, message in self._scrape_tasks.get_progress_history(session_id):
+                events.append(_build_scrape_event(step, phase, message))
 
         for step, phase, message in self._scrape_tasks.drain_progress(session_id):
             events.append(_build_scrape_event(step, phase, message))
@@ -276,6 +336,15 @@ class ChatV2Agent:
                 )
             else:
                 events.append(data_event("website_summary", result))
+        elif not state.get("ad_plan", {}).get("websiteSummary"):
+            # Full result not ready — emit partial summary if available
+            partial = self._scrape_tasks.get_partial_summary(session_id)
+            if partial:
+                events.append(data_event("website_summary", {
+                    "summary": partial.get("summary", ""),
+                    "business_url": state.get("ad_plan", {}).get("websiteURL", ""),
+                    "partial": True,
+                }))
 
         competitors = self._merge_competitors_if_ready(session_id, state)
         if competitors:
@@ -314,11 +383,11 @@ class ChatV2Agent:
             return None
 
         status = state.get("status", ChatStatus.IN_PROGRESS)
-        hold_statuses = {
-            ChatStatus.IN_PROGRESS, ChatStatus.IN_PROGRESS.value,
-            ChatStatus.CONFIRMING_LOCATION, ChatStatus.CONFIRMING_LOCATION.value,
+        # Only show competitors after all account selection is complete
+        allow_statuses = {
+            ChatStatus.AWAITING_CONFIRMATION, ChatStatus.AWAITING_CONFIRMATION.value,
         }
-        if status in hold_statuses:
+        if status not in allow_statuses:
             return None
 
         result = self._competitor_tasks.get_result_if_ready(session_id)
@@ -347,11 +416,28 @@ def _try_parse_competitor_selection(message: str) -> list[str] | None:
     return None
 
 
+SCRAPE_LABELS = {
+    "scrape_pages": "Reading your website...",
+    "screenshot": "Taking a look at your site...",
+    "extract_metadata": "Identifying your business...",
+    "extract_summary": "Understanding your products & services...",
+    "resolve_geo_targets": "Mapping your target areas...",
+    "save": "Saving analysis...",
+}
+
+
 def _build_scrape_event(step: str, phase: str, message: str) -> StreamEvent:
     """Convert a scrape progress tuple into a StreamEvent."""
+    if step == "__summary_chunk__":
+        return data_event("summary_chunk", {"token": message})
+    if step == "__screenshot__":
+        return data_event("screenshot", {"url": message})
+    label = SCRAPE_LABELS.get(step, message)
     if phase == "start":
-        return progress_event(node=f"scrape:{step}", phase="start", label=message)
-    return progress_event(node=f"scrape:{step}", phase="end", message=message)
+        return progress_event(node=f"scrape:{step}", phase="start", label=label)
+    if phase == "end":
+        return progress_event(node=f"scrape:{step}", phase="end", message=message)
+    return progress_event(node=f"scrape:{step}", phase="update", message=message)
 
 
 chatv2_agent = ChatV2Agent()

--- a/agents/chatv2/graph.py
+++ b/agents/chatv2/graph.py
@@ -6,20 +6,17 @@ Flow Diagram:
     Entry (_route_entry)
          │
          ├─ COMPLETED ──► END
-         ├─ CONFIRMING_LOCATION ──► confirm_location ──► predict_budget / END
+         ├─ CONFIRMING_LOCATION ──► confirm_location ──► fetch_parent_account / END
          ├─ SELECTING_PARENT_ACCOUNT ──► select_parent_account ──► fetch_account / END
          ├─ SELECTING_ACCOUNT ──► select_account ──► show_summary ──► END
          ├─ AWAITING_CONFIRMATION ──► confirm ──► END
          │
          └─ IN_PROGRESS (default):
-              collect_data
+              collect_data (budget predicted here if needed)
                    │
                    ▼ (all fields → SELECTING_PARENT_ACCOUNT)
               confirm_location
                    │ (real estate → pause for map, else passthrough)
-                   ▼
-              predict_budget
-                   │ (Google + targetLeads → predict, else passthrough)
                    ▼
               fetch_parent_account
                    │
@@ -45,7 +42,6 @@ from structlog import get_logger
 from agents.chatv2.nodes import (
     collect_data_node,
     confirm_location_node,
-    predict_budget_node,
     confirm_node,
     show_summary_node,
     fetch_parent_account_options,
@@ -60,13 +56,47 @@ logger = get_logger(__name__)
 
 COLLECT_DATA = "collect_data"
 CONFIRM_LOCATION = "confirm_location"
-PREDICT_BUDGET = "predict_budget"
 FETCH_PARENT_ACCOUNT = "fetch_parent_account"
 SELECT_PARENT_ACCOUNT = "select_parent_account"
 FETCH_ACCOUNT = "fetch_account"
 SELECT_ACCOUNT = "select_account"
 SHOW_SUMMARY = "show_summary"
 CONFIRM = "confirm"
+
+NODE_LABELS = {
+    COLLECT_DATA: "Collecting campaign details",
+    CONFIRM_LOCATION: "Confirming location",
+    FETCH_PARENT_ACCOUNT: "Loading manager accounts",
+    SELECT_PARENT_ACCOUNT: "Processing account selection",
+    FETCH_ACCOUNT: "Loading ad accounts",
+    SELECT_ACCOUNT: "Processing account selection",
+    SHOW_SUMMARY: "Preparing summary",
+    CONFIRM: "Processing confirmation",
+}
+
+
+def _wrap_node(node_name: str, node_fn):
+    """Wrap a node to auto-emit step_start/step_end progress events."""
+
+    async def wrapped(state: ChatState):
+        from langgraph.config import get_stream_writer
+
+        writer = get_stream_writer()
+        label = NODE_LABELS.get(node_name, node_name)
+        writer({"type": "progress", "node": node_name, "phase": "start", "label": label})
+        try:
+            result = await node_fn(state)
+            writer({"type": "progress", "node": node_name, "phase": "end"})
+            return result
+        except Exception:
+            writer(
+                {"type": "progress", "node": node_name, "phase": "end", "content": "Error"}
+            )
+            raise
+
+    wrapped.__name__ = node_fn.__name__
+    return wrapped
+
 
 STATUS_TO_NODE = {
     ChatStatus.COMPLETED: END,
@@ -91,15 +121,14 @@ def _build_graph() -> CompiledStateGraph:
     """Build and compile the chat state graph."""
     graph = StateGraph[ChatState, None, ChatState, ChatState](ChatState)
 
-    graph.add_node(COLLECT_DATA, collect_data_node)
-    graph.add_node(CONFIRM_LOCATION, confirm_location_node)
-    graph.add_node(PREDICT_BUDGET, predict_budget_node)
-    graph.add_node(FETCH_PARENT_ACCOUNT, fetch_parent_account_options)
-    graph.add_node(SELECT_PARENT_ACCOUNT, select_parent_account_node)
-    graph.add_node(FETCH_ACCOUNT, fetch_account_options)
-    graph.add_node(SELECT_ACCOUNT, select_account_node)
-    graph.add_node(SHOW_SUMMARY, show_summary_node)
-    graph.add_node(CONFIRM, confirm_node)
+    graph.add_node(COLLECT_DATA, _wrap_node(COLLECT_DATA, collect_data_node))
+    graph.add_node(CONFIRM_LOCATION, _wrap_node(CONFIRM_LOCATION, confirm_location_node))
+    graph.add_node(FETCH_PARENT_ACCOUNT, _wrap_node(FETCH_PARENT_ACCOUNT, fetch_parent_account_options))
+    graph.add_node(SELECT_PARENT_ACCOUNT, _wrap_node(SELECT_PARENT_ACCOUNT, select_parent_account_node))
+    graph.add_node(FETCH_ACCOUNT, _wrap_node(FETCH_ACCOUNT, fetch_account_options))
+    graph.add_node(SELECT_ACCOUNT, _wrap_node(SELECT_ACCOUNT, select_account_node))
+    graph.add_node(SHOW_SUMMARY, _wrap_node(SHOW_SUMMARY, show_summary_node))
+    graph.add_node(CONFIRM, _wrap_node(CONFIRM, confirm_node))
 
     graph.set_conditional_entry_point(
         _route_entry,
@@ -121,11 +150,6 @@ def _build_graph() -> CompiledStateGraph:
     graph.add_conditional_edges(
         CONFIRM_LOCATION,
         _route_after_location,
-        {PREDICT_BUDGET: PREDICT_BUDGET, END: END},
-    )
-    graph.add_conditional_edges(
-        PREDICT_BUDGET,
-        _route_after_predict,
         {FETCH_PARENT_ACCOUNT: FETCH_PARENT_ACCOUNT, END: END},
     )
     graph.add_conditional_edges(
@@ -163,14 +187,7 @@ def _route_after_collect(state: ChatState) -> str:
 
 
 def _route_after_location(state: ChatState) -> str:
-    """After location: proceed to budget prediction if confirmed, else pause for map."""
-    if _get_status(state) == ChatStatus.SELECTING_PARENT_ACCOUNT:
-        return PREDICT_BUDGET
-    return END
-
-
-def _route_after_predict(state: ChatState) -> str:
-    """After prediction: proceed to account fetch if budget is set, else back to collect."""
+    """After location: proceed to account fetch if confirmed, else pause for map."""
     if _get_status(state) == ChatStatus.SELECTING_PARENT_ACCOUNT:
         return FETCH_PARENT_ACCOUNT
     return END

--- a/agents/chatv2/nodes/collect_data.py
+++ b/agents/chatv2/nodes/collect_data.py
@@ -29,30 +29,21 @@ async def collect_data_node(state: ChatState) -> dict[str, Any]:
     """Collect campaign business data through AI-powered conversation."""
     logger.info("Entering collect_data_node")
     writer = get_stream_writer()
-    writer(
-        {
-            "type": "progress",
-            "node": "collect_data",
-            "phase": "start",
-            "label": "Collecting campaign details",
-        }
-    )
 
     ad_plan = dict(state.get("ad_plan") or {})
+    session_id = get_config()["configurable"]["thread_id"]
+
     messages = [
         SystemMessage(content=_get_system_prompt()),
         *state["messages"],
-        SystemMessage(content=_build_context(ad_plan)),
+        SystemMessage(content=_build_context(ad_plan, session_id)),
     ]
 
-    tool_choice = "required" if ad_plan else "auto"
     reply_text, tool_calls, response = await get_llm_adapter().chat_with_tools(
         messages=messages,
         tools=get_collection_tools(),
-        tool_choice=tool_choice,
+        tool_choice="auto",
     )
-
-    session_id = get_config()["configurable"]["thread_id"]
 
     _emit_reasoning(writer, tool_calls)
     ad_plan, tool_result = await _process_tool_call(
@@ -65,6 +56,7 @@ async def collect_data_node(state: ChatState) -> dict[str, Any]:
         ad_plan = await _fallback_url_extract(state, ad_plan, writer, session_id)
 
     if _has_all_fields(ad_plan):
+        ad_plan = _predict_budget_if_needed(ad_plan, writer)
         new_status = ChatStatus.SELECTING_PARENT_ACCOUNT
         platform = ad_plan.get("platform", "google")
         label = "Meta" if platform == "meta" else "Google"
@@ -76,8 +68,13 @@ async def collect_data_node(state: ChatState) -> dict[str, Any]:
                 "content": f"All details collected! Moving to {label} account selection...",
             }
         )
-        # Skip follow-up LLM call — next node will provide the response
-        response_message = ""
+        # Use LLM's reply if it produced one, otherwise brief acknowledgment
+        if reply_text.strip():
+            response_message = reply_text.strip()
+        elif tool_calls:
+            response_message = f"Got it! Setting up your {label} campaign..."
+        else:
+            response_message = ""
     else:
         if tool_result:
             reply_text = await _get_followup_response(
@@ -173,14 +170,13 @@ async def _get_followup_response(
 
 async def _get_continuation_response(state: ChatState, ad_plan: dict) -> str:
     """Get AI response when tool succeeded but LLM didn't provide conversational reply."""
-    context = _build_context(ad_plan)
     required = _get_dynamic_required(ad_plan)
     missing = [f for f in required if f not in ad_plan]
     messages = [
         SystemMessage(content=_get_system_prompt()),
         *state["messages"],
         SystemMessage(
-            content=f"[SYSTEM] Tool call succeeded. {context} Acknowledge what was saved and ask for the next missing field ({missing[0] if missing else 'none'})."
+            content=f"[SYSTEM] Tool call succeeded. Acknowledge what was saved and continue. Still need: {missing if missing else 'nothing — all fields collected'}."
         ),
     ]
 
@@ -244,21 +240,101 @@ def _start_background_scrape(session_id: str, url: str) -> None:
     )
 
 
-def _build_context(ad_plan: dict) -> str:
-    """Build context message with collected values and missing fields."""
+def _build_context(ad_plan: dict, session_id: str) -> str:
+    """Build context with collected fields + scrape intelligence for LLM."""
     required = _get_dynamic_required(ad_plan)
     collected = {f: ad_plan[f] for f in required if f in ad_plan}
     missing = [f for f in required if f not in ad_plan]
     total = len(required)
     n = len(collected)
+
+    parts = []
     if not collected:
-        return (
-            "[CONTEXT] No fields collected yet. This is the start of the conversation."
+        parts.append("[CONTEXT] No fields collected yet.")
+    else:
+        parts.append(
+            f"[CONTEXT] Collected ({n}/{total}): {json.dumps(collected)}. "
+            f"Still need: {missing}."
         )
-    return (
-        f"[CONTEXT] Collected ({n}/{total}): {json.dumps(collected)}. "
-        f"Still need: {missing}."
-    )
+
+    scrape = _get_scrape_context(ad_plan, session_id)
+    if scrape:
+        parts.append(scrape)
+
+    return "\n\n".join(parts)
+
+
+def _get_scrape_context(ad_plan: dict, session_id: str) -> str | None:
+    """Extract business intelligence from scrape for LLM context."""
+    from agents.chatv2.scrape_manager import get_scrape_task_manager
+
+    ws = ad_plan.get("websiteSummary")
+    if isinstance(ws, dict) and "error" not in ws:
+        return _format_scrape_for_llm(ws)
+
+    mgr = get_scrape_task_manager()
+    partial = mgr.get_partial_summary(session_id)
+    if partial:
+        return (
+            "[SCRAPE_DATA] (partial — analysis ongoing)\n"
+            f"Summary: {partial.get('summary', '')}"
+        )
+
+    if mgr.has_active_scrape(session_id):
+        return "[SCRAPE_DATA] Website analysis in progress. Infer what you can from the user's message."
+
+    return None
+
+
+def _format_scrape_for_llm(summary: dict) -> str:
+    """Format full scrape result as LLM context."""
+    parts = ["[SCRAPE_DATA]"]
+    if summary.get("business_type"):
+        parts.append(f"Business type: {summary['business_type']}")
+    if summary.get("summary"):
+        parts.append(f"About: {summary['summary'][:500]}")
+
+    loc = summary.get("location")
+    if isinstance(loc, dict):
+        loc_parts = [v for k, v in loc.items() if v and isinstance(v, str)]
+        if loc_parts:
+            parts.append(f"Location: {', '.join(loc_parts[:3])}")
+
+    geo = summary.get("suggested_geo_targets")
+    if geo:
+        names = [g.get("name", "") for g in geo[:5] if g.get("name")]
+        if names:
+            parts.append(f"Geo targets: {', '.join(names)}")
+
+    return "\n".join(parts)
+
+
+def _predict_budget_if_needed(ad_plan: dict, writer: Callable) -> dict:
+    """Predict budget from targetLeads when Google + no budget. Returns updated ad_plan."""
+    if ad_plan.get("platform") != "google":
+        return ad_plan
+    if "budget" in ad_plan or "targetLeads" not in ad_plan:
+        return ad_plan
+
+    import math
+    from mlops.google_search.budget_prediction.api import get_initialized_predictor
+
+    predictor = get_initialized_predictor()
+    if not predictor.is_ready():
+        logger.warning("budget_predictor_not_ready")
+        return ad_plan
+
+    target_leads = ad_plan["targetLeads"]
+    duration_days = ad_plan["durationDays"]
+    result = predictor.predict(conversions=target_leads, duration_days=duration_days)
+
+    raw = result.suggested_budget / duration_days
+    daily_budget = int(math.ceil(raw / 1000) * 1000) if raw > 1000 else int(math.ceil(raw / 100) * 100)
+    ad_plan = {**ad_plan, "budget": str(daily_budget)}
+
+    writer({"type": "field_update", "field": "budget", "value": str(daily_budget), "status": "valid"})
+    logger.info("budget_predicted", target_leads=target_leads, daily_budget=daily_budget)
+    return ad_plan
 
 
 _URL_RE = re.compile(

--- a/agents/chatv2/nodes/confirm.py
+++ b/agents/chatv2/nodes/confirm.py
@@ -27,14 +27,6 @@ async def show_summary_node(state: ChatState) -> dict[str, Any]:
     """Build and display campaign summary. Runs once when entering confirmation."""
     writer = get_stream_writer()
     ad_plan = dict(state["ad_plan"])
-    writer(
-        {
-            "type": "progress",
-            "node": "show_summary",
-            "phase": "start",
-            "label": "Preparing summary",
-        }
-    )
     summary = build_summary(ad_plan, state)
     writer(
         {
@@ -54,14 +46,6 @@ async def confirm_node(state: ChatState) -> dict[str, Any]:
     """Handle user response to campaign summary — confirm, modify, or change account."""
     logger.info("Entering confirm_node")
     writer = get_stream_writer()
-    writer(
-        {
-            "type": "progress",
-            "node": "confirm",
-            "phase": "start",
-            "label": "Processing confirmation",
-        }
-    )
 
     ad_plan = dict(state["ad_plan"])
 
@@ -129,7 +113,7 @@ def build_summary(ad_plan: dict, state: ChatState) -> str:
 
     field_labels = {
         "platform": "Platform",
-        "businessName": "Business Name",
+        "productName": "Product Name",
         "websiteURL": "Website",
         "budget": "Budget",
         "durationDays": "Duration",

--- a/agents/chatv2/nodes/confirm_location.py
+++ b/agents/chatv2/nodes/confirm_location.py
@@ -53,13 +53,6 @@ async def _handle_first_entry(
     scrape_result = await _wait_for_scrape(session_id)
 
     if not scrape_result or not _is_real_estate(scrape_result):
-        writer(
-            {
-                "type": "progress",
-                "node": "confirm_location",
-                "phase": "end",
-            }
-        )
         return {}
 
     ad_plan = dict(state.get("ad_plan") or {})
@@ -134,7 +127,7 @@ async def _handle_user_response(
             "area_location": None,
             "geo_targets": geo_targets,
         }
-        reply = "Location updated. Proceeding with campaign setup."
+        reply = f"Location saved ({coordinates['lat']:.4f}, {coordinates['lng']:.4f}). Now setting up your ad accounts."
     else:
         existing_selection = state.get("location_selection") or {}
         ad_plan["location"] = {
@@ -145,15 +138,18 @@ async def _handle_user_response(
                 existing_selection.get("coordinates")
             ),
         }
-        reply = "Location confirmed. Proceeding with campaign setup."
+        loc_name = existing_selection.get("product_location") or existing_selection.get("area_location") or "your location"
+        reply = f"Location confirmed: {loc_name}. Now setting up your ad accounts."
 
-    writer(
-        {
-            "type": "progress",
-            "node": "confirm_location",
-            "phase": "end",
-        }
-    )
+    location = ad_plan.get("location", {})
+    attachment = {
+        "type": "confirmed_location",
+        "label": location.get("product_location")
+            or location.get("area_location")
+            or "Selected location",
+    }
+    if location.get("coordinates"):
+        attachment["coordinates"] = location["coordinates"]
 
     return {
         "status": ChatStatus.SELECTING_PARENT_ACCOUNT,
@@ -161,6 +157,7 @@ async def _handle_user_response(
         "messages": [AIMessage(content=reply)],
         "ad_plan": ad_plan,
         "location_selection": None,
+        "intermediate_messages": [{"reply": reply, "attachments": [attachment]}],
     }
 
 
@@ -185,10 +182,10 @@ async def _wait_for_scrape(
 
 
 def _is_real_estate(result: WebsiteSummaryResponse) -> bool:
-    """Check if the scraped business is real estate."""
+    """Check if the scraped business is in the real estate category."""
     if not result.business_type:
         return False
-    return result.business_type.strip().lower() == REAL_ESTATE_TYPE
+    return REAL_ESTATE_TYPE in result.business_type.strip().lower()
 
 
 def _get_last_user_message(state: ChatState) -> str:

--- a/agents/chatv2/nodes/select_account.py
+++ b/agents/chatv2/nodes/select_account.py
@@ -105,12 +105,20 @@ async def fetch_account_options(state: ChatState) -> dict[str, Any]:
                 "label": f"Auto-selected {config['account_label']}: {child_name}",
             }
         )
+        account_attachment = {
+            "type": "confirmed_account",
+            "name": child_name,
+            "id": children[0].get("id"),
+            "account_type": "account",
+        }
+        reply = f"Auto-selected {config['account_label']}: {child_name}"
         return {
             "ad_plan": new_ad_plan,
             "account_options": children,
             "status": status,
-            "response_message": f"Auto-selected {config['account_label']}: {child_name}",
+            "response_message": reply,
             "account_selection": None,
+            "intermediate_messages": [{"reply": reply, "attachments": [account_attachment]}],
         }
 
     writer(
@@ -121,10 +129,14 @@ async def fetch_account_options(state: ChatState) -> dict[str, Any]:
             "label": f"Found {len(children)} {config['account_label']}s",
         }
     )
+    parent_name = next(
+        (a.get("name") for a in parent_options if str(a.get("id")) == str(parent_id)),
+        parent_id,
+    )
     return {
         "account_options": children,
         "status": ChatStatus.SELECTING_ACCOUNT,
-        "response_message": f"{config['account_label'].capitalize()}s under {config['parent_label']} {parent_id}:",
+        "response_message": f"{config['account_label'].capitalize()}s under {config['parent_label']} {parent_name}:",
         "account_selection": AccountSelection.account_selection(children).model_dump(),
     }
 
@@ -199,6 +211,13 @@ async def select_account_node(state: ChatState) -> dict[str, Any]:
         else f"{config['account_label'].capitalize()} selected"
     )
 
+    account_attachment = {
+        "type": "confirmed_account",
+        "name": selected_name or selected_id,
+        "id": selected_id,
+        "account_type": "account",
+    }
+
     if all_fields_collected(new_ad_plan, config):
         writer(
             {
@@ -212,6 +231,7 @@ async def select_account_node(state: ChatState) -> dict[str, Any]:
             "ad_plan": new_ad_plan,
             "status": ChatStatus.AWAITING_CONFIRMATION,
             "account_selection": None,
+            "intermediate_messages": [{"reply": end_label, "attachments": [account_attachment]}],
         }
 
     writer(
@@ -227,6 +247,7 @@ async def select_account_node(state: ChatState) -> dict[str, Any]:
         "status": ChatStatus.IN_PROGRESS,
         "response_message": f"{config['account_label'].capitalize()} selected.",
         "account_selection": None,
+        "message_attachments": [account_attachment],
     }
 
 

--- a/agents/chatv2/nodes/select_parent_account.py
+++ b/agents/chatv2/nodes/select_parent_account.py
@@ -82,11 +82,19 @@ async def fetch_parent_account_options(state: ChatState) -> dict[str, Any]:
         new_ad_plan = dict(state["ad_plan"])
         new_ad_plan[config["parent_id_field"]] = parent_id
 
+        account_attachment = {
+            "type": "confirmed_account",
+            "name": parent_name,
+            "id": parent_id,
+            "account_type": "parent",
+        }
+        reply = f"Found 1 {label} — auto-selected {parent_name}"
         return {
             "ad_plan": new_ad_plan,
             "parent_account_options": parents,
             "status": ChatStatus.SELECTING_ACCOUNT,
-            "response_message": f"Auto-selected {label}: {parent_name}",
+            "response_message": reply,
+            "intermediate_messages": [{"reply": reply, "attachments": [account_attachment]}],
         }
 
     writer(
@@ -175,10 +183,18 @@ async def select_parent_account_node(state: ChatState) -> dict[str, Any]:
             "label": f"Selected: {selected_name}",
         }
     )
+    account_attachment = {
+        "type": "confirmed_account",
+        "name": selected_name,
+        "id": selected_id,
+        "account_type": "parent",
+    }
+    reply = f"Selected {config['parent_label']}: {selected_name}"
     return {
         "ad_plan": new_ad_plan,
         "status": ChatStatus.SELECTING_ACCOUNT,
-        "response_message": f"Selected {config['parent_label']}: {selected_name}",
+        "response_message": reply,
+        "intermediate_messages": [{"reply": reply, "attachments": [account_attachment]}],
     }
 
 

--- a/agents/chatv2/platform_config.py
+++ b/agents/chatv2/platform_config.py
@@ -13,7 +13,7 @@ PLATFORM_CONFIG = {
         "progress_load_children": "Loading Google customer accounts",
         "progress_select_account": "Selecting Google customer account",
         "required_fields": [
-            "businessName",
+            "productName",
             "websiteURL",
             "budget",
             "durationDays",
@@ -34,7 +34,7 @@ PLATFORM_CONFIG = {
         "progress_load_children": "Loading Meta ad accounts",
         "progress_select_account": "Selecting Meta ad account",
         "required_fields": [
-            "businessName",
+            "productName",
             "websiteURL",
             "budget",
             "durationDays",

--- a/agents/chatv2/scrape_manager.py
+++ b/agents/chatv2/scrape_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -29,6 +29,8 @@ class ScrapeJob:
     result: Optional[WebsiteSummaryResponse] = field(default=None)
     error: Optional[str] = field(default=None)
     progress: asyncio.Queue = field(default_factory=asyncio.Queue)
+    progress_history: list = field(default_factory=list)
+    partial_summary: Optional[dict] = field(default=None)
 
 
 class ScrapeTaskManager:
@@ -68,16 +70,35 @@ class ScrapeTaskManager:
             return job.error
         return None
 
+    def get_partial_summary(self, session_id: str) -> Optional[dict]:
+        """Return partial summary if available (before scrape completes)."""
+        job = self._scrape_jobs.get(session_id)
+        if job and job.partial_summary:
+            return job.partial_summary
+        return None
+
     def has_active_scrape(self, session_id: str) -> bool:
         """Check if a scrape task is currently running for this session."""
         job = self._scrape_jobs.get(session_id)
         return job is not None and not job.task.done()
 
     async def subscribe_progress(
-        self, session_id: str
+        self, session_id: str, *, wait_for_job: bool = False, wait_timeout: float = 60
     ) -> AsyncIterator[tuple[str, str, str]]:
-        """Yield progress tuples in real-time. Exits when task completes and queue is empty."""
+        """Yield progress tuples in real-time. Exits when task completes and queue is empty.
+
+        If *wait_for_job* is True, polls up to *wait_timeout* seconds for a job to appear
+        (useful when the scrape is started mid-graph and subscribe is called before it exists).
+        """
         job = self._scrape_jobs.get(session_id)
+        if not job and wait_for_job:
+            elapsed = 0.0
+            while elapsed < wait_timeout:
+                await asyncio.sleep(0.5)
+                elapsed += 0.5
+                job = self._scrape_jobs.get(session_id)
+                if job:
+                    break
         if not job:
             return
         while True:
@@ -89,6 +110,13 @@ class ScrapeTaskManager:
             except asyncio.TimeoutError:
                 if job.task.done():
                     break
+
+    def get_progress_history(self, session_id: str) -> list[tuple[str, str, str]]:
+        """Return all progress events seen so far (non-destructive)."""
+        job = self._scrape_jobs.get(session_id)
+        if not job:
+            return []
+        return list(job.progress_history)
 
     def drain_progress(self, session_id: str) -> list[tuple[str, str, str]]:
         """Return and clear all buffered progress events (non-blocking)."""
@@ -110,25 +138,32 @@ class ScrapeTaskManager:
             self._cancel_job(session_id, job)
 
     async def _run_scrape(self, session_id: str, url: str, auth: AuthParams) -> None:
-        from agents.scrape.scrape_agent import ScrapeAgent
-
-        def on_progress(step: str, phase: str, message: str) -> None:
-            job = self._scrape_jobs.get(session_id)
-            if job and job.url == url:
-                job.progress.put_nowait((step, phase, message))
+        from agents.scrape.scrape_agent import scrape_agent
+        from core.infrastructure.context import set_auth_context
 
         try:
-            result = await ScrapeAgent().run(
+            set_auth_context(
+                access_token=auth.access_token,
+                client_code=auth.client_code,
+                x_forwarded_host=auth.x_forwarded_host,
+                x_forwarded_port=auth.x_forwarded_port,
+            )
+            result = await scrape_agent.run(
                 url=url,
                 access_token=auth.access_token,
                 client_code=auth.client_code,
                 x_forwarded_host=auth.x_forwarded_host,
                 x_forwarded_port=auth.x_forwarded_port,
-                on_progress=on_progress,
+                on_progress=self._make_progress_callback(session_id, url),
+                on_data=self._make_data_callback(session_id, url),
             )
             job = self._scrape_jobs.get(session_id)
             if job and job.url == url:
                 job.result = result
+                # Mark the last scrape step as completed
+                last_step = job.progress_history[-1][0] if job.progress_history else "save"
+                job.progress_history.append((last_step, "end", "Analysis complete"))
+                job.progress.put_nowait((last_step, "end", "Analysis complete"))
                 logger.info(
                     "background_scrape_completed",
                     session_id=session_id,
@@ -145,6 +180,50 @@ class ScrapeTaskManager:
             job = self._scrape_jobs.get(session_id)
             if job and job.url == url:
                 job.error = str(e)
+
+    def _make_progress_callback(
+        self, session_id: str, url: str
+    ) -> Callable[[str, str, str], None]:
+        seen_steps: set[str] = set()
+
+        def on_progress(step: str, phase: str, message: str) -> None:
+            job = self._scrape_jobs.get(session_id)
+            if job and job.url == url:
+                # Auto-promote first event per step to "start" so the frontend
+                # creates a new progress step entry in the sidebar.
+                effective_phase = phase
+                if phase == "update" and step not in seen_steps:
+                    effective_phase = "start"
+                seen_steps.add(step)
+                job.progress_history.append((step, effective_phase, message))
+                job.progress.put_nowait((step, effective_phase, message))
+
+        return on_progress
+
+    def _make_data_callback(
+        self, session_id: str, url: str
+    ) -> Callable[[str, dict], None]:
+        def on_data(data_type: str, data: dict) -> None:
+            job = self._scrape_jobs.get(session_id)
+            if not job or job.url != url:
+                return
+            if data_type == "summary":
+                job.partial_summary = data.get("payload", data)
+                logger.info("partial_summary_captured", session_id=session_id)
+            elif data_type == "summary_chunk":
+                payload = data.get("payload", data)
+                token = payload.get("token", "")
+                if token:
+                    # Forward chunk through progress queue with special sentinel
+                    job.progress.put_nowait(("__summary_chunk__", "data", token))
+            elif data_type == "screenshot":
+                payload = data.get("payload", data)
+                screenshot_url = payload.get("url", "")
+                if screenshot_url:
+                    job.progress.put_nowait(("__screenshot__", "data", screenshot_url))
+                    logger.info("screenshot_forwarded", session_id=session_id)
+
+        return on_data
 
     def _cancel_job(self, session_id: str, job: ScrapeJob) -> None:
         if not job.task.done():

--- a/agents/chatv2/state.py
+++ b/agents/chatv2/state.py
@@ -7,6 +7,15 @@ from langchain_core.messages import BaseMessage
 from core.chatv2.models import ChatStatus
 
 
+def _append_list(
+    existing: list[dict[str, Any]], new: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Reducer: append new items. Pass sentinel '__clear__' to reset."""
+    if new and new[0].get("__clear__"):
+        return []
+    return existing + new
+
+
 class ChatState(TypedDict):
     """Main state for the chat graph."""
 
@@ -18,6 +27,8 @@ class ChatState(TypedDict):
     response_message: str
     account_selection: Optional[dict[str, Any]]
     location_selection: Optional[dict[str, Any]]
+    message_attachments: Annotated[list[dict[str, Any]], _append_list]
+    intermediate_messages: Annotated[list[dict[str, Any]], _append_list]
 
 
 def create_initial_state() -> ChatState:
@@ -31,4 +42,6 @@ def create_initial_state() -> ChatState:
         response_message="",
         account_selection=None,
         location_selection=None,
+        message_attachments=[],
+        intermediate_messages=[],
     )

--- a/api/chatv2.py
+++ b/api/chatv2.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query, Request
 
 from agents.chatv2.chat_agent import chatv2_agent
 from core.streaming.sse import sse_response
@@ -8,22 +8,34 @@ from utils.response_helpers import success_response
 
 router = APIRouter(prefix="/api/ds/chatv2", tags=["chatv2"])
 
-# TODO: merge start-session into /stream — first message auto-creates session,
-#       eliminating the extra round trip before the user sees a response.
+
+@router.post("/stream")
+async def stream_chat(
+    message: str,
+    request: Request,
+    session_id: Optional[str] = Query(None),
+):
+    """Single chat endpoint — auto-creates session if none provided.
+
+    First message: omit session_id → creates session, emits session_init event.
+    Subsequent messages: pass session_id → continues existing session.
+    """
+    if session_id:
+        chatv2_agent.validate_session(session_id)
+
+    return sse_response(
+        chatv2_agent.process_message_stream(session_id, message),
+        request=request,
+        session_id=session_id or "",
+    )
 
 
-@router.post("/start-session")
-async def start_session() -> dict[str, Any]:
-    result = await chatv2_agent.start_session()
-    return success_response(data=result)
-
-
-@router.post("/{session_id}/stream")
-async def stream_chat_process(session_id: str, message: str):
-    """Process a chat message with SSE streaming response."""
+@router.post("/{session_id}/cancel")
+async def cancel_session(session_id: str):
+    """Cancel an in-progress chat operation."""
     chatv2_agent.validate_session(session_id)
-    event_stream = chatv2_agent.process_message_stream(session_id, message)
-    return sse_response(event_stream)
+    chatv2_agent.cancel(session_id)
+    return success_response(data={"cancelled": True})
 
 
 @router.get("/{session_id}")

--- a/apis/business_api.py
+++ b/apis/business_api.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Header, Body
+from structlog import get_logger
 from dependencies.header_dependencies import CommonHeaders, get_common_headers
 from models.business_model import ScreenshotRequest, WebsiteSummaryRequest
 from services.business_service import BusinessService
@@ -11,6 +12,8 @@ from services.screenshot_service import ScreenshotService
 from services.final_summary_service import generate_final_summary
 from utils.response_helpers import success_response
 from utils.response_helpers import error_response
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/ds/business", tags=["business"])
 
@@ -118,3 +121,53 @@ async def generate_final_summary_endpoint(
         x_forwarded_port=headers.x_forwarded_port,
     )
     return success_response(result)
+
+
+@router.post("/websiteSummary/stream")
+async def website_summary_stream(payload: WebsiteSummaryRequest = Body(...)):
+    """SSE streaming endpoint for website scrape + summary pipeline."""
+    from agents.scrape.scrape_agent import scrape_agent
+    from core.streaming.sse import sse_response
+
+    return sse_response(
+        scrape_agent.process_stream(payload.business_url, rescrape=payload.rescrape)
+    )
+
+
+@router.post("/screenshot/stream")
+async def screenshot_stream(payload: ScreenshotRequest = Body(...)):
+    """SSE streaming endpoint for screenshot capture."""
+    from agents.scrape.scrape_agent import scrape_agent
+    from core.streaming.sse import sse_response
+
+    return sse_response(
+        scrape_agent.process_stream(
+            payload.business_url, retake_screenshot=payload.retake
+        )
+    )
+
+
+@router.post("/generate/external-summary/stream")
+async def external_summary_stream(payload: WebsiteSummaryRequest = Body(...)):
+    """SSE streaming endpoint for external link scrape + summary."""
+    from agents.scrape.scrape_agent import scrape_agent
+    from core.streaming.sse import sse_response
+
+    return sse_response(
+        scrape_agent.process_stream(
+            payload.business_url,
+            rescrape=payload.rescrape,
+            external_url=payload.external_url,
+        )
+    )
+
+
+@router.post("/generate/final-summary/stream")
+async def final_summary_stream(
+    business_url: str = Body(..., embed=True),
+):
+    """SSE streaming endpoint for final summary generation."""
+    from agents.scrape.scrape_agent import scrape_agent
+    from core.streaming.sse import sse_response
+
+    return sse_response(scrape_agent.process_stream(business_url))

--- a/apis/chat_api.py
+++ b/apis/chat_api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Query
 from services import chat_service
+from services.adzump_session_bridge import create_session_from_adzump
 
 router = APIRouter(prefix="/api/ds/chat", tags=["chat"])
 
@@ -9,7 +10,18 @@ async def start_session():
     return await chat_service.start_session()
 
 
-@router.post("/{session_id}") 
+@router.post("/from-adzump-session/{adzump_session_id}")
+async def start_session_from_adzump(adzump_session_id: str):
+    """Pull an adzump session from nocode-ai and seed a ds session from it.
+
+    Auth headers (Authorization, clientCode, X-Forwarded-Host/Port) must be
+    on the incoming request — they're forwarded to nocode-ai so the user's
+    own permission scope governs what data we can read.
+    """
+    return await create_session_from_adzump(adzump_session_id)
+
+
+@router.post("/{session_id}")
 async def chat(session_id: str, message: str, clientCode: str = Query(...)):
     return await chat_service.process_chat(session_id, message, clientCode)
 

--- a/core/chatv2/fields/registry.py
+++ b/core/chatv2/fields/registry.py
@@ -23,16 +23,16 @@ FIELD_REGISTRY: dict[str, FieldDef] = {
         error_msg="Please specify 'google' or 'meta' as the platform",
         required=True,
     ),
-    "businessName": FieldDef(
-        type=str,
-        description="Name of the business/company",
-        required=True,
-    ),
     "websiteURL": FieldDef(
         type=str,
         description="Website URL (e.g., example.com or https://example.com)",
         validator="validate_website",
         error_msg="Please provide a valid URL like example.com or https://example.com",
+        required=True,
+    ),
+    "productName": FieldDef(
+        type=str,
+        description="Name of the product being marketed",
         required=True,
     ),
     "budget": FieldDef(

--- a/core/chatv2/models.py
+++ b/core/chatv2/models.py
@@ -74,9 +74,10 @@ class ChatResponse(BaseModel):
     status: str
     reply: str
     collected_data: dict[str, Any]
-    progress: str
     account_selection: Optional[dict[str, Any]] = None
     location_selection: Optional[dict[str, Any]] = None
+    message_attachments: list[dict[str, Any]] = []
+    intermediate_messages: list[dict[str, Any]] = []
 
 
 class SessionResponse(BaseModel):
@@ -84,5 +85,4 @@ class SessionResponse(BaseModel):
 
     status: str
     data: Optional[dict[str, Any]]
-    progress: str
     last_activity: Optional[str] = None

--- a/core/infrastructure/session_store.py
+++ b/core/infrastructure/session_store.py
@@ -14,6 +14,7 @@ from structlog import get_logger
 logger = get_logger(__name__)
 
 SESSION_TIMEOUT = timedelta(minutes=30)
+MAX_EVENT_LOG_SIZE = 500
 
 
 class SessionStore:
@@ -27,6 +28,8 @@ class SessionStore:
     def __init__(self, timeout: timedelta = SESSION_TIMEOUT):
         self._sessions: dict[str, dict] = {}
         self._timeout = timeout
+        self._cancelled: dict[str, bool] = {}
+        self._event_logs: dict[str, list[tuple[int, str]]] = {}
 
     def create(self, initial_data: Optional[dict] = None) -> str:
         """Create a new session. Returns session ID."""
@@ -71,6 +74,8 @@ class SessionStore:
         """Delete a session. Returns True if existed."""
         if session_id in self._sessions:
             del self._sessions[session_id]
+            self._cancelled.pop(session_id, None)
+            self.clear_event_log(session_id)
             logger.info("Session deleted", session_id=session_id)
             return True
         return False
@@ -84,6 +89,35 @@ class SessionStore:
         session = self._sessions.get(session_id)
         return session["last_activity"] if session else None
 
+    def mark_cancelled(self, session_id: str) -> bool:
+        """Mark session for cancellation. Returns False if session doesn't exist."""
+        if session_id not in self._sessions:
+            return False
+        self._cancelled[session_id] = True
+        return True
+
+    def is_cancelled(self, session_id: str) -> bool:
+        """Check if session has been marked for cancellation."""
+        return self._cancelled.get(session_id, False)
+
+    def clear_cancelled(self, session_id: str) -> None:
+        """Clear cancellation flag."""
+        self._cancelled.pop(session_id, None)
+
+    def append_event(self, session_id: str, seq: int, frame: str) -> None:
+        """Append an SSE frame to the session's event log for reconnection replay."""
+        log = self._event_logs.setdefault(session_id, [])
+        log.append((seq, frame))
+        if len(log) > MAX_EVENT_LOG_SIZE:
+            log.pop(0)
+
+    def get_events_after(self, session_id: str, after_id: int) -> list[str]:
+        """Return SSE frames with sequence number > after_id."""
+        return [frame for seq, frame in self._event_logs.get(session_id, []) if seq > after_id]
+
+    def clear_event_log(self, session_id: str) -> None:
+        """Remove all stored events for a session."""
+        self._event_logs.pop(session_id, None)
 
 
 # Singleton instance

--- a/core/streaming/event_schemas.py
+++ b/core/streaming/event_schemas.py
@@ -1,0 +1,77 @@
+"""Typed payload schemas for SSE stream events.
+
+Each model corresponds to one event type in the ChatV2 streaming protocol.
+Used by factory functions in events.py and can be exported to TypeScript
+via scripts/generate_ts_types.py.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class ContentPayload(BaseModel):
+    token: str
+    node: str = ""
+
+
+class ProgressPayload(BaseModel):
+    node: str
+    message: str = ""
+    phase: Literal["start", "update", "end"] = "update"
+    label: str = ""
+
+
+class FieldUpdatePayload(BaseModel):
+    field: str
+    value: Any
+    status: Literal["valid", "pending", "invalid"] = "valid"
+    error: str | None = None
+
+
+class DonePayload(BaseModel):
+    status: str
+    reply: str = ""
+    collected_data: dict[str, Any] = {}
+    account_selection: dict[str, Any] | None = None
+    location_selection: dict[str, Any] | None = None
+
+
+class ErrorPayload(BaseModel):
+    message: str
+    code: int = 500
+    recoverable: bool = False
+
+
+class WebsiteSummaryPayload(BaseModel):
+    summary: str = ""
+    final_summary: str = ""
+    business_url: str = ""
+    business_type: str = ""
+    partial: bool = False
+    storage_id: str = ""
+
+
+class CompetitorSelectionPayload(BaseModel):
+    competitors: list[dict[str, Any]]
+
+
+class SummaryChunkPayload(BaseModel):
+    token: str
+
+
+class ToolCallPayload(BaseModel):
+    name: str
+    args: dict[str, Any]
+    result: Any = None
+
+
+class StatusPayload(BaseModel):
+    status: str
+    progress: str
+    node: str = ""
+
+
+class StateDeltaPayload(BaseModel):
+    node: str
+    fields: dict[str, Any]

--- a/core/streaming/events.py
+++ b/core/streaming/events.py
@@ -12,6 +12,7 @@ class StreamEvent(BaseModel):
 
     event: EventType
     data: dict[str, Any]
+    id: str | None = None
 
     def to_sse(self) -> str:
         return f"event: {self.event}\ndata: {self.model_dump_json()}\n\n"
@@ -42,8 +43,11 @@ def status_event(status: str, progress: str, node: str = "") -> StreamEvent:
     )
 
 
-def data_event(data_type: str, payload: dict) -> StreamEvent:
-    return StreamEvent(event="data", data={"type": data_type, "payload": payload})
+def data_event(
+    data_type: str, payload: "dict | BaseModel", id: str | None = None
+) -> StreamEvent:
+    serialized = payload.model_dump() if isinstance(payload, BaseModel) else payload
+    return StreamEvent(event="data", data={"type": data_type, "payload": serialized}, id=id)
 
 
 def error_event(

--- a/core/streaming/langgraph_translator.py
+++ b/core/streaming/langgraph_translator.py
@@ -8,6 +8,7 @@ Final state is retrieved via graph.aget_state() (MemorySaver checkpointer),
 not through stream_mode — keeps the streaming loop a clean pass-through.
 """
 
+from core.streaming.event_schemas import FieldUpdatePayload
 from core.streaming.events import (
     StreamEvent,
     content_event,
@@ -24,6 +25,8 @@ def translate_stream_chunk(mode: str, chunk) -> list[StreamEvent]:
         return _handle_custom_event(chunk)
     if mode == "messages":
         return _handle_message_chunk(chunk)
+    if mode == "updates":
+        return _handle_state_update(chunk)
     return []
 
 
@@ -45,12 +48,12 @@ def _handle_custom_event(data: dict) -> list[StreamEvent]:
         return [
             data_event(
                 "field_update",
-                {
-                    "field": data.get("field", ""),
-                    "value": data.get("value"),
-                    "status": data.get("status", ""),
-                    "error": data.get("error"),
-                },
+                FieldUpdatePayload(
+                    field=data.get("field", ""),
+                    value=data.get("value"),
+                    status=data.get("status", "valid"),
+                    error=data.get("error"),
+                ),
             )
         ]
 
@@ -83,3 +86,31 @@ def _handle_message_chunk(chunk) -> list[StreamEvent]:
         node = metadata.get("langgraph_node", "")
         return [content_event(token=content, node=node)]
     return []
+
+
+_SKIP_AD_PLAN_FIELDS = frozenset({
+    "startDate", "endDate", "websiteSummary",
+    "competitors", "suggested_competitors",
+})
+
+
+def _handle_state_update(chunk: dict) -> list[StreamEvent]:
+    """Handle updates stream mode: emit field_update events for ad_plan changes."""
+    events: list[StreamEvent] = []
+    for node_name, state_diff in chunk.items():
+        if not isinstance(state_diff, dict):
+            continue
+        ad_plan = state_diff.get("ad_plan")
+        if ad_plan and isinstance(ad_plan, dict):
+            for field, value in ad_plan.items():
+                if field not in _SKIP_AD_PLAN_FIELDS and value is not None:
+                    events.append(
+                        data_event(
+                            "field_update",
+                            FieldUpdatePayload(field=field, value=value, status="valid"),
+                        )
+                    )
+        status = state_diff.get("status")
+        if status:
+            events.append(status_event(status=str(status), progress="", node=node_name))
+    return events

--- a/core/streaming/sse.py
+++ b/core/streaming/sse.py
@@ -1,17 +1,36 @@
+import asyncio
 from collections.abc import AsyncIterator
 
+from fastapi import Request
 from fastapi.responses import StreamingResponse
-from structlog import get_logger
+from structlog import get_logger  # type: ignore
 
+from core.infrastructure.session_store import SessionStore, get_session_store
 from core.streaming.events import StreamEvent, error_event
 
 logger = get_logger(__name__)
 
+HEARTBEAT_INTERVAL_SECONDS = 15
 
-def sse_response(event_generator: AsyncIterator[StreamEvent]) -> StreamingResponse:
-    """Wrap an async event generator into a FastAPI SSE StreamingResponse."""
+
+def sse_response(
+    event_generator: AsyncIterator[StreamEvent],
+    request: Request | None = None,
+    session_id: str | None = None,
+) -> StreamingResponse:
+    """Wrap an async event generator into a FastAPI SSE StreamingResponse.
+
+    Args:
+        event_generator: Async iterator of StreamEvent objects.
+        request: Optional FastAPI Request — used to read ``Last-Event-ID``
+            header for replay on reconnect.
+        session_id: Optional session ID — when provided, events are persisted
+            to the session store for reconnection replay beyond the ring buffer.
+    """
+    last_event_id = _parse_last_event_id(request)
+    store = get_session_store() if session_id else None
     return StreamingResponse(
-        _sse_stream(event_generator),
+        _sse_stream(event_generator, last_event_id=last_event_id, store=store, session_id=session_id),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -21,13 +40,74 @@ def sse_response(event_generator: AsyncIterator[StreamEvent]) -> StreamingRespon
     )
 
 
-async def _sse_stream(events: AsyncIterator[StreamEvent]) -> AsyncIterator[str]:
-    """Convert StreamEvents to SSE wire format with error safety net."""
+async def _sse_stream(
+    events: AsyncIterator[StreamEvent],
+    last_event_id: int = 0,
+    store: SessionStore | None = None,
+    session_id: str | None = None,
+) -> AsyncIterator[str]:
+    """Convert StreamEvents to SSE wire format with heartbeat and replay.
+
+    Features:
+        - Auto-incrementing ``id:`` on every event frame.
+        - Heartbeat comment (``: heartbeat``) every 15 s of inactivity.
+        - Persistent event log in session store for ``Last-Event-ID`` replay.
+    """
+    # Replay missed events from persistent store on reconnect
+    if last_event_id > 0 and store and session_id:
+        stored_frames = store.get_events_after(session_id, last_event_id)
+        for frame in stored_frames:
+            yield frame
+        if stored_frames:
+            logger.info("sse_replay_from_store", session_id=session_id, count=len(stored_frames), after_id=last_event_id)
+
+    seq = last_event_id
+
+    async def _next_event(ait: AsyncIterator[StreamEvent]) -> StreamEvent:
+        return await ait.__anext__()
+
     try:
-        async for event in events:
-            yield event.to_sse()
+        while True:
+            try:
+                event = await asyncio.wait_for(
+                    _next_event(events), timeout=HEARTBEAT_INTERVAL_SECONDS
+                )
+            except asyncio.TimeoutError:
+                yield ": heartbeat\n\n"
+                continue
+            except StopAsyncIteration:
+                break
+
+            seq += 1
+            frame = f"id: {seq}\n{event.to_sse()}"
+
+            if store and session_id:
+                store.append_event(session_id, seq, frame)
+
+            yield frame
+            logger.debug(
+                "sse_event",
+                seq=seq,
+                event_type=event.event,
+                reconciliation_id=event.id,
+            )
     except Exception as e:
-        logger.exception("SSE stream error: %s", e)
-        yield error_event(str(e), recoverable=False).to_sse()
+        seq += 1
+        logger.exception("sse_stream_error", seq=seq, error=str(e))
+        frame = f"id: {seq}\n{error_event(str(e), recoverable=False).to_sse()}"
+        if store and session_id:
+            store.append_event(session_id, seq, frame)
+        yield frame
     finally:
         yield ":\n\n"
+
+
+def _parse_last_event_id(request: Request | None) -> int:
+    """Extract ``Last-Event-ID`` header as an int, defaulting to 0."""
+    if request is None:
+        return 0
+    raw = request.headers.get("Last-Event-ID", "0")
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return 0

--- a/docs/chatv2_event_flow.md
+++ b/docs/chatv2_event_flow.md
@@ -1,0 +1,465 @@
+# ChatV2 SSE Event Flow - Complete Reference
+
+## Overview
+
+ChatV2 uses a LangGraph state machine to orchestrate a multi-step campaign creation conversation. Each user message triggers a graph invocation that streams SSE events to the frontend. The graph **terminates** at pause points (account selection, location confirmation) and **re-enters** on the next message based on `ChatStatus`.
+
+## Architecture
+
+```
+Frontend (SSE Client)
+    |
+    v
+POST /api/ds/chatv2/stream?session_id=...
+    |
+    v
+ChatV2Agent.process_message_stream()
+    |
+    +---> LangGraph.astream(stream_mode=["custom","messages","updates"])
+    |         |
+    |         +---> "custom"   --> nodes emit via get_stream_writer()
+    |         +---> "messages" --> LLM token-by-token chunks
+    |         +---> "updates"  --> state diffs after each node
+    |
+    +---> ScrapeTaskManager (concurrent asyncio task)
+    |
+    v
+translate_stream_chunk() --> StreamEvent --> SSE wire format
+```
+
+### Three Stream Modes
+
+| Mode | What it captures | Translator |
+|------|-----------------|------------|
+| `custom` | Node-emitted events via `get_stream_writer()` (progress, field_update, status) | `_handle_custom_event` |
+| `messages` | LLM token chunks as `(AIMessageChunk, metadata)` tuples | `_handle_message_chunk` |
+| `updates` | Full state diff after each node completes | `_handle_state_update` |
+
+### Event Types
+
+| Event | Purpose |
+|-------|---------|
+| `progress` | Step indicators: `{node, phase: start\|update\|end, label, message}` |
+| `content` | LLM streaming tokens: `{token, node}` |
+| `data` | Structured payloads: `field_update`, `website_summary`, `screenshot`, `summary_chunk`, `competitor_selection`, `analysis_complete`, `session_init` |
+| `status` | State machine transitions: `{status, progress, node}` |
+| `done` | End of graph invocation: full response payload |
+| `error` | Error with `{message, code, recoverable}` |
+
+---
+
+## Complete Session Walkthrough (Real Captured Events)
+
+This traces an actual session for a real estate campaign (Purva Atmosphere, Bangalore).
+
+---
+
+### Request 1: Initial Message (e.g. "hi")
+
+**Graph path**: `_route_entry(IN_PROGRESS)` -> `collect_data` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1 | `progress(collect_data, start, "Collecting campaign details")` | progress | `_wrap_node` | Node wrapper auto-emits |
+| 2-15 | `content(token="Let's"..."?")` | content | `messages` mode | LLM streams token by token |
+| 16 | `progress(collect_data, end)` | progress | `_wrap_node` | |
+| 17 | `content(full message)` | content | `messages` mode | **ISSUE: Full message re-emitted as single chunk** |
+| 18 | `status(ChatStatus.IN_PROGRESS)` | status | `updates` mode | State diff after node |
+| 19 | `done({status: "in_progress", reply: "...", collected_data: {}})` | done | `_emit_completion` | Graph complete |
+| - | `: ` (heartbeat/close) | comment | SSE layer | Connection close marker |
+
+**Status**: `IN_PROGRESS` -> stays `IN_PROGRESS`
+**Collected fields**: none
+
+---
+
+### Request 2: User Sends URL
+
+User: `"https://www.puravankara.com/residential/bengaluru/purva-atmosphere"`
+
+**Graph path**: `collect_data` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1 | `progress(collect_data, start)` | progress | `_wrap_node` | |
+| 2-48 | `content(tokens)` | content | `messages` | LLM streams response |
+| 49 | `data(field_update, {websiteURL, valid})` | data | `custom` | From `_process_tool_call` or `_fallback_url_extract` |
+| 50 | `data(field_update, {websiteSummary, pending})` | data | `custom` | Background scrape kicked off |
+| 51 | `progress(collect_data, end)` | progress | `_wrap_node` | |
+| 52 | `content(full message again)` | content | `messages` | **DUPLICATE: full echo** |
+| 53 | `data(field_update, {websiteURL, valid})` | data | `updates` | **DUPLICATE: from state diff** |
+| 54 | `status(IN_PROGRESS)` | status | `updates` | |
+| 55 | `done(...)` | done | agent | |
+| 56-57 | `progress(scrape:cache_check, start/end)` | progress | post-done scrape | Cache hit - no full scrape needed |
+| 58 | `data(website_summary, {full result})` | data | `_drain_buffered_scrape` | Cached scrape result merged |
+| 59 | `data(analysis_complete, {business_name, summary, ...})` | data | agent | Summary card for frontend |
+
+**Key behavior**: Scrape was a cache hit (previously analyzed URL), so full result arrives immediately after `done`. The `done` event fires FIRST to unblock user input.
+
+**Status**: stays `IN_PROGRESS`
+**Collected fields**: `websiteURL`
+
+---
+
+### Request 3: User Says "google" (Platform)
+
+**Graph path**: `collect_data` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1-2 | `progress(scrape:cache_check, start/end)` | progress | scrape replay | **Replayed every request** |
+| 3 | `progress(collect_data, start)` | progress | `_wrap_node` | |
+| 4-54 | `content(tokens)` | content | `messages` | LLM talks about Purva Atmosphere, asks duration |
+| 55 | `progress(collect_data, end)` | progress | `_wrap_node` | |
+| 56 | `content(full message)` | content | `messages` | **DUPLICATE echo** |
+| 57 | `data(field_update, {websiteURL})` | data | `updates` | **DUPLICATE: unchanged field re-emitted** |
+| 58 | `status(IN_PROGRESS)` | status | `updates` | |
+| 59 | `done(...)` | done | agent | |
+
+**Observation**: LLM did NOT call `update_ad_plan` tool this turn. It inferred "google" but didn't save it. The `productName` was mentioned conversationally but not extracted via tool. This means `collected_data` in `done` still only shows `websiteURL`.
+
+**Status**: stays `IN_PROGRESS`
+**Collected fields**: `websiteURL` (only - platform/productName not saved yet)
+
+---
+
+### Request 4: User Says "2 months" (Duration)
+
+**Graph path**: `collect_data` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1-2 | scrape cache_check replay | progress | | |
+| 3 | `progress(collect_data, start)` | progress | | |
+| 4-35 | `content(tokens)` | content | | LLM asks about leads/budget |
+| 36 | `progress(collect_data, end)` | progress | | |
+| 37 | `content(full message)` | content | | **DUPLICATE** |
+| 38 | `data(field_update, {websiteURL})` | data | `updates` | **DUPLICATE: same field, every turn** |
+| 39 | `status(IN_PROGRESS)` | status | | |
+| 40 | `done(...)` | done | | |
+
+**Same issue**: LLM said "60 days" conversationally but did NOT call the tool. `durationDays` not in `collected_data`.
+
+**Status**: stays `IN_PROGRESS`
+**Collected fields**: `websiteURL` (still only 1 field!)
+
+---
+
+### Request 5: User Provides Budget (+ LLM Bulk Saves)
+
+User gives budget. LLM finally calls `update_ad_plan` with ALL fields at once.
+
+**Graph path**: `collect_data` -> `confirm_location` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1-2 | scrape cache_check replay | progress | | |
+| 3 | `progress(collect_data, start)` | progress | `_wrap_node` | |
+| 4 | `progress(collect_data, update, "User provided budget 6000...")` | progress | `_emit_reasoning` | LLM reasoning from tool args |
+| 5-8 | `data(field_update, {platform\|productName\|budget\|durationDays})` | data | `custom` | From `_process_tool_call` - valid fields |
+| 9-10 | `data(field_update, {websiteURL\|websiteSummary:pending})` | data | `custom` | URL re-extracted + pending scrape |
+| 11 | `progress(collect_data, update, "All details collected!")` | progress | node | Transition signal |
+| 12 | `progress(collect_data, end)` | progress | `_wrap_node` | |
+| 13 | `content(full message)` | content | `messages` | "Got it! Setting up your Google campaign..." |
+| 14-18 | `data(field_update, {websiteURL\|platform\|productName\|budget\|durationDays})` | data | `updates` | **DUPLICATE: all fields again from state diff** |
+| 19 | `status(SELECTING_PARENT_ACCOUNT)` | status | `updates` | State transition |
+| 20 | `progress(confirm_location, start)` | progress | `_wrap_node` | **Graph continues to next node** |
+| 21 | `progress(confirm_location, start, "Checking business location")` | progress | node | **DUPLICATE start** |
+| 22 | `progress(confirm_location, end, "Location review")` | progress | node | |
+| 23 | `progress(confirm_location, end)` | progress | `_wrap_node` | **DUPLICATE end** |
+| 24 | `content("We couldn't detect a property location...")` | content | `messages` | |
+| 25-30 | `data(field_update, {all fields + businessType})` | data | `updates` | **DUPLICATE: entire ad_plan re-emitted** |
+| 31 | `status(CONFIRMING_LOCATION)` | status | `updates` | |
+| 32 | `done({status: "confirming_location", location_selection: {map_url: ...}})` | done | agent | **PAUSE POINT** |
+
+**This is the critical turn**: LLM saved 4 fields at once, graph flowed through `collect_data` -> `confirm_location` in one invocation. Location not found in scrape, so map shown with India center coordinates.
+
+**Status**: `IN_PROGRESS` -> `SELECTING_PARENT_ACCOUNT` -> `CONFIRMING_LOCATION`
+**Collected fields**: websiteURL, platform, productName, budget, durationDays, businessType
+
+---
+
+### Request 6: User Sends Location Pin
+
+User: `{"type": "location_update", "lat": 12.8673, "lng": 77.5868}`
+
+**Graph path**: `_route_entry(CONFIRMING_LOCATION)` -> `confirm_location` -> `fetch_parent_account` -> `fetch_account` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1-2 | scrape cache_check replay | progress | | |
+| 3 | `progress(confirm_location, start)` | progress | `_wrap_node` | |
+| 4 | `progress(confirm_location, start, "Processing location")` | progress | node | |
+| 5 | `progress(confirm_location, end)` | progress | `_wrap_node` | |
+| 6 | `content("Location saved (12.8673, 77.5868)...")` | content | `messages` | |
+| 7-13 | `data(field_update, {all fields + location})` | data | `updates` | **DUPLICATE: full ad_plan** |
+| 14 | `status(SELECTING_PARENT_ACCOUNT)` | status | `updates` | |
+| 15 | `progress(fetch_parent_account, start)` | progress | `_wrap_node` | **Continues** |
+| 16 | `progress(fetch_parent_account, start, "Finding your Google Ads accounts")` | progress | node | |
+| 17 | `progress(fetch_parent_account, end, "Auto-selected manager account: Modlix")` | progress | node | **Single MCC = auto-select** |
+| 18 | `progress(fetch_parent_account, end)` | progress | `_wrap_node` | |
+| 19-26 | `data(field_update, {all fields + loginCustomerId})` | data | `updates` | **DUPLICATE: entire ad_plan again** |
+| 27 | `status(SELECTING_ACCOUNT)` | status | `updates` | |
+| 28 | `progress(fetch_account, start)` | progress | `_wrap_node` | **Continues** |
+| 29 | `progress(fetch_account, start, "Loading Google customer accounts")` | progress | node | |
+| 30 | `progress(fetch_account, end, "Found 5 customer accounts")` | progress | node | Multiple = pause |
+| 31 | `progress(fetch_account, end)` | progress | `_wrap_node` | |
+| 32 | `status(SELECTING_ACCOUNT)` | status | `updates` | |
+| 33 | `done({status: "selecting_account", account_selection: {5 options}, intermediate_messages: [location confirmed, MCC auto-selected]})` | done | agent | **PAUSE POINT** |
+
+**Three nodes in one invocation**: `confirm_location` -> `fetch_parent_account` (auto-selected) -> `fetch_account` (5 options, pause). The `intermediate_messages` array carries the location confirmation and MCC auto-selection as breadcrumbs for the frontend.
+
+**Status**: `CONFIRMING_LOCATION` -> `SELECTING_PARENT_ACCOUNT` -> `SELECTING_ACCOUNT`
+**Collected fields**: + location, loginCustomerId
+
+---
+
+### Request 7: User Selects Account
+
+User: `"4220436668"` (Fincity Common Ads)
+
+**Graph path**: `_route_entry(SELECTING_ACCOUNT)` -> `select_account` -> `show_summary` -> `END`
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1-2 | scrape cache_check replay | progress | | |
+| 3 | `progress(select_account, start)` | progress | `_wrap_node` | |
+| 4 | `progress(select_account, start, "Selecting Google customer account")` | progress | node | |
+| 5 | `progress(select_account, end, "Selected: Fincity Common Ads")` | progress | node | |
+| 6 | `progress(select_account, end)` | progress | `_wrap_node` | |
+| 7-15 | `data(field_update, {all fields + customerId})` | data | `updates` | **DUPLICATE: full ad_plan** |
+| 16 | `status(AWAITING_CONFIRMATION)` | status | `updates` | |
+| 17 | `progress(show_summary, start)` | progress | `_wrap_node` | |
+| 18 | `progress(show_summary, end, "Awaiting confirmation")` | progress | node | |
+| 19 | `progress(show_summary, end)` | progress | `_wrap_node` | |
+| 20 | `content(campaign summary text)` | content | `messages` | Full summary with all fields |
+| 21 | `done({status: "selecting_account", ...})` | done | agent | **Status OVERRIDDEN** (see below) |
+| 22 | `data(competitor_selection, {8 competitors})` | data | `_merge_competitors_if_ready` | Post-done competitor data |
+
+**Status override**: The graph sets `AWAITING_CONFIRMATION`, but `_build_response` detects `suggested_competitors` exist without confirmed `competitors`, so it overrides status to `selecting_account` to hold back the confirmation UI. The reply is also overridden to "Please review and select the competitors."
+
+**Status**: `SELECTING_ACCOUNT` -> `AWAITING_CONFIRMATION` (internally) -> `selecting_account` (sent to frontend)
+**Collected fields**: + customerId
+
+---
+
+### Request 8: User Confirms Competitors
+
+User: `{"type": "competitor_selection", "competitors": ["Brigade Group", ...]}`
+
+**Graph path**: SHORT-CIRCUITED (no graph invocation)
+
+| Seq | Event | Type | Source | Notes |
+|-----|-------|------|--------|-------|
+| 1 | `progress(competitors, start, "Saving competitors")` | progress | `process_message_stream` | Handled before graph |
+| 2 | `data(field_update, {competitors, [8 names]})` | data | agent | |
+| 3 | `progress(competitors, end, "8 competitor(s) saved")` | progress | agent | |
+| 4 | `done({status: "awaiting_confirmation", reply: summary, intermediate_messages: [confirmed_competitors]})` | done | agent | Final summary now visible |
+
+**Special path**: `_try_parse_competitor_selection()` intercepts the JSON message BEFORE graph invocation. No LangGraph involved. The `_build_response` now sees `competitors` in ad_plan, so the hold-back logic no longer applies - full summary with `awaiting_confirmation` status is sent.
+
+**Status**: `AWAITING_CONFIRMATION` (real this time)
+
+---
+
+## Event Source Matrix
+
+Shows which source produces which event across the session:
+
+| Event | `custom` (writer) | `messages` (LLM) | `updates` (state diff) | Agent (pre/post graph) |
+|-------|:-:|:-:|:-:|:-:|
+| progress(node, start) | x (node) + x (wrapper) | | | |
+| progress(node, end) | x (node) + x (wrapper) | | | |
+| progress(node, update) | x | | | |
+| content(tokens) | | x (streaming) | | |
+| content(full message) | | x (echo) | | |
+| field_update (new field) | x | | x | |
+| field_update (unchanged) | | | x | |
+| status | | | x | |
+| done | | | | x |
+| scrape progress | | | | x |
+| website_summary | | | | x |
+| competitor_selection | | | | x |
+
+---
+
+## Duplicate Event Analysis
+
+The `updates` stream mode causes significant duplication because it emits the FULL state diff after every node, which includes all ad_plan fields - not just changed ones.
+
+### Duplicates Per Request
+
+| Request | Unique Events | Duplicate Events | Ratio |
+|---------|:---:|:---:|:---:|
+| 1 (hi) | 18 | 1 (content echo) | 5% |
+| 2 (URL) | 55 | 4 (1 content echo + 1 field_update + 2 scrape) | 7% |
+| 3 (google) | 56 | 3 (1 content echo + 1 field_update + 1 status) | 5% |
+| 4 (2 months) | 37 | 3 | 8% |
+| 5 (budget - all fields) | 32 | ~14 (2x field_update per field + content echo + 2x progress per node) | 44% |
+| 6 (location pin) | 33 | ~22 (3 nodes x full ad_plan re-emit) | 67% |
+| 7 (account select) | 22 | ~12 (2 nodes x full ad_plan) | 55% |
+| 8 (competitors) | 4 | 0 | 0% |
+
+**The duplication problem scales with collected fields**: As more fields accumulate in `ad_plan`, every node transition re-emits ALL of them via `updates` mode. By request 6, there are 7+ fields x 3 node transitions = 21+ redundant field_update events.
+
+### Double Progress Events
+
+Every node gets TWO `start` and TWO `end` events:
+1. `_wrap_node` emits `start` (generic)
+2. Node itself emits `start` (with specific label)
+3. Node emits `end` (with specific label)
+4. `_wrap_node` emits `end` (generic)
+
+---
+
+## Critique & Suggestions
+
+### Critical Issues
+
+**1. `updates` stream mode causes O(fields x nodes) duplicate field_updates**
+
+The `updates` mode emits the full `ad_plan` state diff after every node. Since `ad_plan` is a flat dict (not using a reducer), LangGraph treats the entire dict as "changed" whenever any node returns `ad_plan`. By request 6, this produces 20+ redundant `field_update` events per request.
+
+**Fix options**:
+- Remove `updates` from `stream_mode` entirely. The `custom` mode already emits field_updates for genuinely changed fields. The only thing `updates` adds is the `status` event, which could be emitted via `custom` instead.
+- Or: add a dedup layer in `_handle_state_update` that tracks previously emitted field values and skips unchanged ones.
+
+**2. Full message echo after streaming tokens**
+
+After the LLM finishes streaming token-by-token (id:2-48), the `messages` mode emits one final chunk containing the FULL concatenated message (id:52). The frontend gets the message twice - once as tokens, once as a blob.
+
+**Fix**: Filter out `AIMessageChunk` where content equals the already-streamed concatenation. Or check if the chunk is a "final" aggregation chunk (LangGraph behavior) and skip it.
+
+**3. Double progress start/end per node**
+
+`_wrap_node` and the node itself both emit `start` and `end`. The frontend sees:
+```
+progress(confirm_location, start, "Confirming location")     <- wrapper
+progress(confirm_location, start, "Checking business location") <- node
+progress(confirm_location, end, "Location review")           <- node
+progress(confirm_location, end, "")                          <- wrapper
+```
+
+**Fix**: Remove progress emission from `_wrap_node` since every node already emits its own start/end with better labels. Or: have `_wrap_node` only emit if the node doesn't.
+
+**4. Status string inconsistency**
+
+`updates` mode emits `"ChatStatus.IN_PROGRESS"` (the enum repr), but `done` event emits `"in_progress"` (the value). Frontend must handle both formats.
+
+**Fix**: In `_handle_state_update`, convert `status` to string value: `str(status.value) if hasattr(status, 'value') else str(status)`.
+
+### Design Concerns
+
+**5. Competitor flow uses status override hack**
+
+When competitors are pending, `_build_response` overrides `AWAITING_CONFIRMATION` to `SELECTING_ACCOUNT` and replaces the reply text. This means the `status` event from `updates` mode says `AWAITING_CONFIRMATION` but the `done` event says `selecting_account`. Frontend sees conflicting signals.
+
+**Suggestion**: Introduce a proper `SELECTING_COMPETITORS` status in `ChatStatus` enum. This makes the state machine explicit rather than relying on response-level overrides.
+
+**6. LLM batches field extraction unpredictably**
+
+In requests 3 and 4, the LLM acknowledges fields conversationally ("60 days", "google") but does NOT call `update_ad_plan`. It waits until request 5 to save everything at once. This means `collected_data` in `done` doesn't reflect what the user has actually provided - it only shows what the LLM has formally saved.
+
+**Suggestion**: Consider a post-LLM extraction step that detects mentioned-but-unsaved fields, or adjust the system prompt to encourage incremental saves. Alternatively, emit "tentative" field_updates based on LLM conversation content even before tool calls.
+
+**7. Scrape cache_check replays on every request**
+
+The `_drain_buffered_scrape_events(replay_history=True)` call at the start of `process_message_stream` replays all historical scrape progress. For a cached scrape, this means `cache_check start/end` appears at the top of EVERY request after the URL is provided.
+
+**Suggestion**: Only replay on SSE reconnect (when `Last-Event-ID` is provided), not on every new message.
+
+**8. No explicit `session_init` in captured data**
+
+The first request's captured events don't show `session_init`. The code in `api/chatv2.py` yields it before the graph stream, but the capture starts at id:1 with `progress(collect_data, start)`. This might mean the session was pre-created via `/start-session`, or the event was consumed before capture began.
+
+### Suggestions for Improvement
+
+**9. Add event deduplication layer**
+
+A thin middleware between `translate_stream_chunk` and the SSE emitter could track `(event_type, field, value)` tuples and suppress duplicates within a single request cycle.
+
+**10. Replace `updates` mode with explicit custom events**
+
+Every useful signal from `updates` mode (status changes, new field values) is already available through `custom` mode or could be trivially added. Removing `updates` would eliminate the largest source of duplication.
+
+**11. Structured `done` payload should include `intermediate_messages` timeline**
+
+The `done` event packs `intermediate_messages` as a flat array, but the frontend needs to reconstruct the order (location confirmed -> MCC selected -> account selected). Adding a `sequence` or `timestamp` field would make reconstruction reliable.
+
+**12. Consider separating graph events from scrape events into named SSE channels**
+
+Currently both graph and scrape events share the same SSE stream with `node` prefixed as `scrape:*`. A cleaner separation (e.g., `event: scrape_progress` vs `event: graph_progress`) would let the frontend route them to different UI areas without parsing node names.
+
+---
+
+## State Machine Diagram
+
+```
+                    +--[IN_PROGRESS]--+
+                    |                 |
+                    v                 |
+              collect_data            |
+                    |                 |
+           (all fields?) --NO------->+
+                    |YES
+                    v
+           confirm_location
+                    |
+           (real estate?) --NO--> passthrough
+                    |YES
+                    v
+           CONFIRMING_LOCATION [PAUSE]
+                    |
+              (user pins)
+                    |
+                    v
+         fetch_parent_account
+                    |
+            (1 parent?) --YES--> auto-select
+                    |NO                |
+                    v                  v
+    SELECTING_PARENT_ACCOUNT    fetch_account
+           [PAUSE]                    |
+              |                (1 account?) --YES--> auto-select
+         (user selects)              |NO                |
+              |                      v                  v
+              +-----------> SELECTING_ACCOUNT      show_summary
+                               [PAUSE]                 |
+                                  |                    v
+                            (user selects)    AWAITING_CONFIRMATION
+                                  |                [PAUSE]
+                                  v                    |
+                            show_summary          (user confirms)
+                                  |                    |
+                                  v                    v
+                        AWAITING_CONFIRMATION      COMPLETED
+                             [PAUSE]
+                                  |
+                          (competitors found?)
+                                  |YES
+                                  v
+                        [competitor selection - inline, no graph]
+                                  |
+                            (user confirms)
+                                  |
+                                  v
+                          AWAITING_CONFIRMATION (real)
+                                  |
+                            (user confirms)
+                                  |
+                                  v
+                             COMPLETED
+```
+
+## SSE Wire Format
+
+```
+id: {incrementing_seq}
+event: {progress|content|data|status|done|error}
+data: {"event":"<type>","data":{...},"id":null}
+
+```
+
+- Heartbeat: `: heartbeat\n\n` every 15s
+- Close marker: `:\n\n`
+- Reconnect: `Last-Event-ID` header replays from persistent store

--- a/docs/chatv2_event_flow_v2.md
+++ b/docs/chatv2_event_flow_v2.md
@@ -1,0 +1,593 @@
+# ChatV2 Event Flow - Visual Guide
+
+> Simple, visual explanation of how the chat system works end-to-end.
+
+---
+
+## The Big Picture
+
+Think of ChatV2 like a **restaurant order system**:
+
+```
+Customer (Frontend)  -->  Waiter (API)  -->  Kitchen (LangGraph)  -->  Side Kitchen (Scrape)
+     |                       |                     |                        |
+     |   "I want pizza"      |                     |                        |
+     |--------------------->|                     |                        |
+     |                       |  Start cooking      |                        |
+     |                       |-------------------->|                        |
+     |                       |                     |  Also analyze website  |
+     |                       |                     |----------------------->|
+     |   "chopping onions"   |<-- progress --------|                        |
+     |<---------------------|                     |                        |
+     |   "adding cheese"     |<-- progress --------|                        |
+     |<---------------------|                     |                        |
+     |   "pizza ready!"      |<-- done ------------|                        |
+     |<---------------------|                     |                        |
+     |   "website analyzed"  |<--------------------------------- result ----|
+     |<---------------------|                     |                        |
+```
+
+The key insight: **the kitchen (graph) and side kitchen (scrape) work in parallel**. The waiter streams updates from both to the customer as they happen.
+
+---
+
+## How a Single Request Works
+
+Every time the user sends a message, this happens:
+
+```
+User sends message
+       |
+       v
+  +-----------------+
+  | 1. PRE-GRAPH    |  Before the graph runs:
+  |  - Replay any   |  - Scrape history replayed (so UI stays in sync)
+  |    scrape events |  - Competitor JSON intercepted (shortcut, no graph needed)
+  +-----------------+
+       |
+       v
+  +-----------------+
+  | 2. GRAPH RUNS   |  LangGraph state machine executes:
+  |  - May run 1-4  |  - Each node streams events as it works
+  |    nodes in a   |  - Multiple nodes can chain in one request
+  |    single pass  |  - Graph STOPS at pause points (needs user input)
+  +-----------------+
+       |
+       v
+  +-----------------+
+  | 3. POST-GRAPH   |  After graph finishes:
+  |  - done event   |  - Done fires FIRST (user can type immediately)
+  |  - scrape tail  |  - Remaining scrape events stream after
+  |  - competitors  |  - Competitor data merged if ready
+  +-----------------+
+```
+
+---
+
+## The State Machine (How the Chat Progresses)
+
+The whole flow is a series of **rooms**. The user moves from room to room:
+
+```
+  ROOM 1                    ROOM 2                ROOM 3              ROOM 4
+  --------                  --------              --------            --------
+  Collecting                Location              Account             Confirmation
+  Campaign Info             (real estate          Selection
+                            only)
+
+  "What's your URL?"                              "Pick your          "Here's your
+  "Which platform?"         "Pin your property     MCC account"        campaign summary.
+  "How long?"               on the map"           "Pick your           Confirm?"
+  "Budget?"                                        ad account"
+
+  [IN_PROGRESS]          [CONFIRMING_LOCATION]   [SELECTING_*]      [AWAITING_CONFIRMATION]
+       |                        |                     |                    |
+       | all fields collected   | user pins location  | user picks         | user says "yes"
+       |----------------------->|-------------------->| accounts           |
+                                                      |----------->------>|
+                                                                          |
+                                                                     [COMPLETED]
+```
+
+**Important**: The user doesn't always visit every room:
+- Room 2 is **SKIPPED** if the business is NOT real estate
+- Room 3 has **auto-select** - if there's only 1 account, it skips ahead automatically
+- Between Room 3 and 4, there's an **inline competitor selection** (no room change)
+
+---
+
+## What Happens in Each Room
+
+### Room 1: Collecting Info (`collect_data` node)
+
+```
+User says something
+       |
+       v
+  +------------------+
+  | LLM reads the    |  The AI figures out what info the user provided
+  | user's message   |  and what's still missing
+  +------------------+
+       |
+       v
+  Does LLM call the update_ad_plan tool?
+       |                    |
+      YES                   NO
+       |                    |
+       v                    v
+  Save fields to        LLM just responds
+  ad_plan state         conversationally
+       |                (field NOT saved yet!)
+       |
+       v
+  Is URL in the saved fields?
+       |           |
+      YES          NO
+       |           |
+       v           |
+  Kick off         |
+  background       |
+  website scrape   |
+       |           |
+       v           v
+  All required fields collected?
+       |                |
+      YES               NO
+       |                |
+       v                v
+  Move to Room 2     Stay in Room 1
+  (or skip to 3)     (ask next question)
+```
+
+**Events the frontend sees:**
+
+```
+progress  -->  "Collecting campaign details"        (start)
+content   -->  "Got" "it" "!" "Setting" "up" "..."  (LLM typing, word by word)
+data      -->  field_update: platform = "google"     (field saved)
+data      -->  field_update: budget = "6000"          (field saved)
+data      -->  field_update: websiteSummary = pending  (scrape started)
+progress  -->  "All details collected!"               (moving on)
+progress  -->  end                                     (node done)
+```
+
+### Room 2: Location Confirmation (`confirm_location` node)
+
+Only for **real estate** businesses. The system checks the scrape result for property coordinates.
+
+```
+  Is business real estate?
+       |              |
+      YES             NO
+       |              |
+       v              v
+  Show map to       Pass through
+  user with         (go straight
+  detected pin      to Room 3)
+       |
+       v
+  PAUSE - wait for user
+       |
+  User confirms or moves pin
+       |
+       v
+  Save coordinates + resolve geo targets
+       |
+       v
+  Move to Room 3
+```
+
+**What the user sees:**
+
+```
+  +----------------------------------+
+  | "We found your property at       |
+  |  Thanisandra, Bangalore"         |
+  |                                  |
+  |  [====== Google Map ======]      |
+  |  [     with pin marker    ]      |
+  |  [========================]      |
+  |                                  |
+  |  [Confirm]  [Adjust on map]     |
+  +----------------------------------+
+```
+
+### Room 3: Account Selection (3 nodes working together)
+
+```
+  fetch_parent_account
+       |
+  How many MCC/manager accounts?
+       |          |           |
+      0           1          2+
+       |          |           |
+       v          v           v
+    Error     Auto-select   PAUSE
+    go back   (no pause!)   Show list to user
+                 |                |
+                 |          User picks one
+                 |                |
+                 v                v
+          fetch_account (child accounts)
+                 |
+          How many ad accounts?
+                 |          |           |
+                0           1          2+
+                 |          |           |
+                 v          v           v
+            No accounts  Auto-select   PAUSE
+            go back to   (no pause!)   Show list to user
+            parent list       |              |
+                              |        User picks one
+                              |              |
+                              v              v
+                        Move to Room 4
+```
+
+**Auto-select is key**: If there's only 1 option at any level, the system picks it automatically and chains to the next step. This means in one request, you might see:
+
+```
+location confirmed -> MCC auto-selected -> 5 accounts found -> PAUSE
+(3 nodes ran in a single request!)
+```
+
+**Events during auto-select chain:**
+
+```
+progress --> "Finding your Google Ads accounts"     (start)
+progress --> "Auto-selected manager: Modlix"        (end - auto picked!)
+progress --> "Loading Google customer accounts"     (start - immediately chains)
+progress --> "Found 5 customer accounts"            (end - multiple = pause)
+done     --> account_selection: [5 options]         (frontend shows picker)
+```
+
+### Room 4: Confirmation (`confirm` + `show_summary` nodes)
+
+```
+  show_summary
+       |
+       v
+  Build summary text from ad_plan
+  "Platform: Google Ads, Budget: 6000..."
+       |
+       v
+  PAUSE - show summary to user
+       |
+  Are there competitors to review?
+       |              |
+      YES             NO
+       |              |
+       v              v
+  Show competitor   Wait for
+  picker first      "yes" / edits
+       |
+  User picks
+  competitors
+       |
+       v
+  Now show summary for confirmation
+       |
+  User says "yes" / makes edits
+       |              |
+     "yes"          edits
+       |              |
+       v              v
+  COMPLETED       Update fields,
+                  re-show summary
+```
+
+---
+
+## The Event Types Explained
+
+Think of events like **text messages from the kitchen to the waiter**:
+
+### `progress` - "I'm working on step X"
+
+```
+  { phase: "start", node: "collect_data", label: "Collecting campaign details" }
+                    ...time passes...
+  { phase: "update", node: "collect_data", message: "User wants Google Ads" }
+                    ...time passes...
+  { phase: "end",   node: "collect_data" }
+```
+
+Like a loading spinner: **start** = spinner appears, **update** = status text changes, **end** = spinner gone.
+
+### `content` - "Here's what the AI is typing"
+
+```
+  { token: "Got" }
+  { token: " it" }
+  { token: "!" }
+  { token: " Setting" }
+  { token: " up" }
+  ...
+```
+
+Letter-by-letter (actually word-by-word) LLM output. Like watching someone type in a chat.
+
+### `data` (field_update) - "A form field was filled in"
+
+```
+  { field: "platform",    value: "google", status: "valid" }
+  { field: "budget",      value: "6000",   status: "valid" }
+  { field: "websiteURL",  value: "...",    status: "invalid", error: "Not a valid URL" }
+  { field: "websiteSummary", value: "...", status: "pending" }  <-- scrape in progress
+```
+
+Three statuses: `valid` (saved), `invalid` (rejected with error), `pending` (processing).
+
+### `data` (other types) - "Here's structured data for the UI"
+
+```
+  website_summary       -->  Full scrape result (business type, summary, location)
+  analysis_complete     -->  Condensed card for the chat bubble
+  screenshot            -->  Website screenshot URL
+  summary_chunk         -->  Streaming summary tokens (like content but for scrape)
+  competitor_selection  -->  List of suggested competitors for picker UI
+  session_init          -->  New session created, here's the ID
+  confirmed_location    -->  (via intermediate_messages) Location was pinned
+  confirmed_account     -->  (via intermediate_messages) Account was selected
+  confirmed_competitors -->  (via intermediate_messages) Competitors confirmed
+```
+
+### `status` - "The state machine moved"
+
+```
+  { status: "in_progress" }              -->  Room 1
+  { status: "confirming_location" }      -->  Room 2
+  { status: "selecting_parent_account" } -->  Room 3 (pick MCC)
+  { status: "selecting_account" }        -->  Room 3 (pick ad account)
+  { status: "awaiting_confirmation" }    -->  Room 4
+  { status: "completed" }               -->  Done!
+```
+
+### `done` - "This request is complete"
+
+The big envelope at the end. Contains EVERYTHING the frontend needs to render the current state:
+
+```json
+{
+  "status": "selecting_account",
+  "reply": "Pick an account:",
+  "collected_data": { "websiteURL": "...", "platform": "google", ... },
+  "progress": "2/3",
+  "account_selection": { "type": "account", "options": [...] },
+  "location_selection": null,
+  "message_attachments": [],
+  "intermediate_messages": [
+    { "reply": "Location saved", "attachments": [{ "type": "confirmed_location" }] },
+    { "reply": "Auto-selected Modlix", "attachments": [{ "type": "confirmed_account" }] }
+  ]
+}
+```
+
+**`intermediate_messages`** = breadcrumbs of what happened automatically during this request. The frontend can render these as small notification cards.
+
+---
+
+## The Scrape Side-Channel
+
+Website analysis runs **in parallel** with the main chat. Here's how they interact:
+
+```
+Timeline:
+=========
+
+Request 2 (user sends URL):
+  |
+  |  MAIN CHANNEL                    SCRAPE CHANNEL
+  |  ============                    ==============
+  |  collect_data starts             scrape job created
+  |  LLM streaming...               |
+  |  field_update: websiteURL        |
+  |  field_update: websiteSummary    |
+  |    = "pending"                   |
+  |  collect_data ends               |
+  |  DONE event fires <----------   |
+  |  (user can type now!)            |
+  |                                  cache_check: hit!
+  |  website_summary event <-------- result ready
+  |  analysis_complete event         |
+  |  CONNECTION CLOSES               done
+  |
+Request 3 (user says "google"):
+  |
+  |  scrape history replayed         (cache_check start/end)
+  |  collect_data starts
+  |  LLM now HAS scrape data
+  |    in its context!
+  |  ...
+```
+
+**Key design decision**: The `done` event fires BEFORE scrape finishes. This lets the user keep chatting immediately. Scrape results trickle in after `done` and update the sidebar.
+
+If the scrape was cached (URL analyzed before), the result is instant - it arrives right after `done`.
+
+---
+
+## Pause Points vs Continuous Flow
+
+```
+PAUSE = graph ends, waits for next user message
+CONTINUOUS = graph chains to next node automatically
+
+Request 5 example (budget provided, real estate):
+  collect_data ----CONTINUOUS----> confirm_location ----PAUSE
+  (all fields)                     (show map, wait for pin)
+
+Request 6 example (user pins location, 1 MCC, 5 accounts):
+  confirm_location --CONTINUOUS--> fetch_parent --CONTINUOUS--> fetch_account --PAUSE
+  (save pin)         (1 MCC,       (5 accounts,
+                      auto-select)  show picker)
+```
+
+**The router decides**: When the graph starts, `_route_entry` checks the current `ChatStatus` to know which room to enter. When a node finishes, conditional edges check the NEW status to decide: continue or stop?
+
+```python
+# Simplified logic:
+def should_continue_after_collect(status):
+    if status == SELECTING_PARENT_ACCOUNT:  # all fields collected
+        return "go to confirm_location"     # CONTINUOUS
+    return "END"                            # PAUSE (still collecting)
+
+def should_continue_after_location(status):
+    if status == SELECTING_PARENT_ACCOUNT:  # location confirmed
+        return "go to fetch_parent"         # CONTINUOUS
+    return "END"                            # PAUSE (showing map)
+```
+
+---
+
+## How `intermediate_messages` Work
+
+When multiple nodes run in one request, the user needs to see what happened at each step. That's what `intermediate_messages` are for.
+
+**Example**: Request 6 runs 3 nodes. The `done` event includes:
+
+```
+intermediate_messages: [
+  {
+    reply: "Location saved (12.86, 77.58). Setting up ad accounts.",
+    attachments: [{ type: "confirmed_location", coordinates: {...} }]
+  },
+  {
+    reply: "Found 1 manager account - auto-selected Modlix",
+    attachments: [{ type: "confirmed_account", name: "Modlix", id: "446..." }]
+  }
+]
+```
+
+Frontend renders these as notification cards above the account picker:
+
+```
+  +------------------------------------------+
+  |  Location confirmed                      |
+  |  [map pin icon] 12.8673, 77.5868         |
+  +------------------------------------------+
+  |  Manager account auto-selected           |
+  |  [check icon] Modlix (4461972633)        |
+  +------------------------------------------+
+  |                                          |
+  |  Select your ad account:                 |
+  |  ( ) Codename Lake and Bloom             |
+  |  ( ) Fincity Common Ads                  |
+  |  ( ) Modlix Dev                          |
+  |  ( ) Raja Datta Share                    |
+  |  ( ) Test customer                       |
+  |                                          |
+  +------------------------------------------+
+```
+
+---
+
+## The Competitor Side-Quest
+
+Competitors are found **in the background** (like scrape) and injected at the right moment:
+
+```
+                   Background                    Main Flow
+                   ==========                    =========
+
+Request 2:         scrape starts
+                        |
+Request 5:         scrape done -------> competitor_find starts
+                                              |
+                                              |         collect_data -> confirm_location
+                                              |         (PAUSE for map)
+Request 6:                                    |         location -> accounts
+                                              |         (PAUSE for account picker)
+Request 7:                              competitors     account selected -> show_summary
+                                        found!          (PAUSE for confirmation)
+                                              |
+                                              +-------> merge into done event
+                                                        status OVERRIDDEN to
+                                                        "selecting_account"
+                                                        (hold back summary,
+                                                         show competitor picker first)
+
+Request 8:         User confirms competitors
+                   (shortcut - no graph!)
+                   Now show real summary with
+                   status: "awaiting_confirmation"
+```
+
+**The override hack**: When competitors are ready but not yet confirmed, the system lies about the status. It says `selecting_account` instead of `awaiting_confirmation` to prevent the frontend from showing the confirm button before competitors are picked.
+
+---
+
+## What the Frontend Should Actually Listen To
+
+Given the duplicates and quirks, here's what matters:
+
+```
+MUST HANDLE:
+  done          -->  THE source of truth. Update entire UI from this.
+  content       -->  Stream into chat bubble (but ignore the final full-echo chunk)
+  progress      -->  Show/hide loading spinners
+  data          -->  field_update from "custom" source = real changes
+                     website_summary = sidebar update
+                     competitor_selection = show picker
+                     analysis_complete = summary card
+
+CAN SAFELY IGNORE:
+  status        -->  Already in done.status (and has enum repr bug)
+  field_update from "updates" mode  -->  Duplicates of custom mode
+  Second progress start/end per node  -->  Wrapper duplicates
+```
+
+---
+
+## Critique & Suggestions
+
+### Problems Found
+
+| # | Problem | Severity | What Happens |
+|---|---------|----------|-------------|
+| 1 | **Duplicate field_updates** from `updates` stream mode | High | Same field emitted 2-3x per node. Grows with fields. By request 6: 67% events are duplicates |
+| 2 | **Full message echo** after token streaming | Medium | LLM response appears twice - once as tokens, once as blob |
+| 3 | **Double progress start/end** per node | Low | Wrapper + node both emit start and end = 4 events instead of 2 |
+| 4 | **Status string bug** | Medium | `updates` sends `"ChatStatus.IN_PROGRESS"`, `done` sends `"in_progress"`. Frontend must handle both |
+| 5 | **Competitor status override** | Medium | `status` event says `AWAITING_CONFIRMATION`, `done` says `selecting_account`. Conflicting signals |
+| 6 | **LLM batches fields unpredictably** | Medium | User says "google" in request 3, but `platform` doesn't appear in `collected_data` until request 5 |
+| 7 | **Scrape replay on every request** | Low | `cache_check start/end` appears at top of every request after URL provided |
+
+### Suggested Fixes
+
+**Quick wins (< 1 hour each):**
+
+1. **Fix status string bug** - In `_handle_state_update`, add:
+   ```python
+   status_val = status.value if hasattr(status, 'value') else str(status)
+   ```
+
+2. **Remove `_wrap_node` progress events** - Every node already emits better labeled start/end. The wrapper ones are generic noise.
+
+3. **Filter the full-message echo** - In `_handle_message_chunk`, skip chunks where content length > 100 chars (the echo is always the full concatenated message).
+
+**Medium effort (half day):**
+
+4. **Remove `updates` from `stream_mode`** - The only thing it provides that `custom` doesn't is the `status` event. Add one `writer()` call in each node to emit status, then drop `updates` entirely. Eliminates ~80% of all duplicates.
+
+5. **Add `SELECTING_COMPETITORS` status** - Make the competitor flow explicit in the state machine instead of hacking status overrides in `_build_response`.
+
+**Larger improvements:**
+
+6. **Force incremental field saves** - Adjust the system prompt to tell the LLM: "Call update_ad_plan after EVERY user message that provides info, even partial." This gives the frontend real-time field tracking.
+
+7. **Only replay scrape on SSE reconnect** - Check for `Last-Event-ID` header before replaying. New messages don't need history.
+
+### Bandwidth Impact of Duplicates
+
+Rough estimate for a full session (8 requests):
+
+```
+Total events emitted:    ~250
+Unique/useful events:    ~150
+Duplicate events:        ~100  (40%)
+
+Wasted bytes:            ~15-20 KB per session
+```
+
+Not a performance crisis, but it makes frontend logic harder (must deduplicate or ignore) and debugging confusing (logs full of repeated events).

--- a/models/business_model.py
+++ b/models/business_model.py
@@ -105,6 +105,7 @@ class WebsiteSummaryResponse(BaseModel):
     unresolved_locations: Optional[List[str]] = None
     competitors: Optional[List[dict]] = None
     competitor_analysis: Optional[List[dict]] = None
+    screenshot: Optional[str] = None
 
 
 class WarningType(str, Enum):

--- a/prompts/chatv2/collect_data.txt
+++ b/prompts/chatv2/collect_data.txt
@@ -1,149 +1,98 @@
-You are an advertising campaign assistant. Your ONLY purpose is collecting campaign data.
+You are AdPilot, a campaign architect for Google Ads and Meta campaigns.
 
-### SCOPE RESTRICTION
-- ONLY respond to advertising campaign-related queries (Google Ads or Meta)
-- If user asks anything unrelated (general chat, other topics, jokes, recommendations):
-  1. Acknowledge warmly: "That sounds interesting!" or "Thanks for sharing!"
-  2. State limitation: "I can only help with advertising campaigns."
-  3. Redirect: "What's your [next missing field]?"
-  Example: "That sounds fun! I can only help with advertising campaigns though. Which platform would you like — Google or Meta?"
-- Do NOT answer off-topic questions, even if you know the answer
+### YOUR APPROACH
+Use website analysis as context to ask smarter questions, but ALWAYS ask — never auto-fill fields.
+User input is the single source of truth. Scrape data helps you be conversational, not to skip questions.
 
-Extract these fields from user messages:
+### SCOPE
+- ONLY help with Google Ads or Meta campaign creation
+- If user asks unrelated things: acknowledge briefly, redirect to campaign setup
+- If platform already known, never re-ask
 
-### REQUIRED FIELDS (all platforms)
-1. **platform** - Advertising platform: "google" or "meta" (also accept: "google ads", "facebook", "fb", "meta ads", "instagram")
-2. **businessName** - Name of the business/company
-3. **websiteURL** - Website URL
-4. **durationDays** - Campaign duration in days
+### REQUIRED FIELDS
+1. **platform** — "google" or "meta"
+2. **websiteURL** — user's website URL (FIRST PRIORITY — ask for this before anything else)
+3. **productName** — product/brand being marketed
+4. **durationDays** — campaign duration in days
 
-### PLATFORM-SPECIFIC FIELDS
-- **Google**: **targetLeads** - How many leads/conversions the user wants from this campaign (e.g., 50, 100).
-  When asking for this field, you MUST always include BOTH options in your response:
-  "How many leads do you want from this campaign? This helps us estimate your daily budget. Or you can directly provide a daily budget instead."
-  NEVER ask for just leads without mentioning the daily budget alternative.
-- **Meta**: **budget** - Daily advertising budget (e.g., 5000 or 5k). Ask: "What's your daily advertising budget?"
+### PLATFORM-SPECIFIC
+- **Google**: needs EITHER **targetLeads** OR **budget** (daily) — NOT both. You MUST always present BOTH options in a single message. Use EXACTLY this format: "How many leads do you want from this campaign? Or you can directly provide a daily budget instead." NEVER ask for just leads without mentioning the budget option.
+- **Meta**: **budget** (daily). Ask: "What's your daily advertising budget?"
 
-**Budget override**: If a Google user provides a budget directly (e.g., "budget is 10k"), accept it with `budget` field — do NOT ask for targetLeads. Budget always takes priority.
+**CRITICAL: budget and targetLeads are mutually exclusive for Google.**
+- If user provides budget → DONE. Do NOT ask for leads. Save budget and move on.
+- If user provides targetLeads → DONE. Budget will be predicted automatically. Do NOT ask for budget.
+- NEVER ask for leads after budget is already provided. NEVER ask for budget after leads are provided.
 
-### TOOL CALLING RULES
+### CRITICAL: USER INPUT ALWAYS WINS
+If the user explicitly provides a value for ANY field, use EXACTLY what the user said — even if scrape data suggests something different. Scrape data is context, not truth. The user knows their product name better than a website scraper.
+
+### INFERENCE RULES (decide vs ask)
+
+**When [SCRAPE_DATA] is in context:**
+- `productName` → INFER from scrape data. Call update_ad_plan({{"productName": "[scraped name]"}}) AND tell the user: "I'll use [X] as the product name — let me know if you'd like to change it." If user corrects it later, update. Do NOT ask "what's the product name?" separately — that's redundant when scrape data has the answer.
+- `platform` → ALWAYS ASK. Never assume. "Which platform — Google Ads or Meta?"
+- `durationDays` → ALWAYS ASK. Never assume a default. "How long should the campaign run?"
+- `budget/targetLeads` → ALWAYS ASK.
+
+**When NO scrape data yet:**
+- Extract whatever you can from the user's message
+- If URL is present, scrape is starting — tell the user: "Analyzing [URL]... I'll have insights shortly."
+- Group remaining questions (max 2 per message)
+
+**When scrape is "in progress":**
+- Acknowledge it: "I'm analyzing your website — meanwhile, [ask what you need]"
+- Don't wait for scrape to finish before engaging
+
+### TOOL CALLING
 - Call `update_ad_plan` IMMEDIATELY when you identify ANY field
-- Even partial data: "50 leads" alone = call with {{"targetLeads": 50}}
-- Extract aggressively - don't wait for perfect formatting
-- Call with multiple fields if user provides them together
-- If user corrects a previously provided field ("actually my business is FitZone not TechCorp"), call update_ad_plan with the new value. The system will overwrite the old value.
+- Extract aggressively — don't wait for perfect formatting
+- Call with multiple fields when user provides them together
 - ALWAYS include `reasoning` explaining what you extracted and why
-  - Good: "User said 'google' — setting platform to google. Will ask for business name next."
-  - Good: "User said '50 leads' — setting targetLeads to 50. Budget will be predicted automatically."
-  - Good: "User said '12k' — interpreting as ₹12,000 budget. Budget provided directly, no need for targetLeads."
-  - Good: "User provided 'cityville.in' — saving as website URL. Will validate format server-side."
-  - Bad: "Updating budget" (too vague, no insight)
+- For productName: save the scraped name immediately and tell user you're using it. They can correct later.
+- For all other fields: only save what the user explicitly stated.
 
-### PLATFORM EXTRACTION
-- "google", "google ads" → platform: "google"
-- "meta", "facebook", "fb", "instagram", "meta ads" → platform: "meta"
-- If user says "I want to run ads on Facebook" → update_ad_plan({{"platform": "meta"}})
-- If user says "Google campaign" → update_ad_plan({{"platform": "google"}})
-- If platform is unclear, ask: "Which platform would you like — Google Ads or Meta?"
+### PROPOSAL STYLE (when scrape data first arrives)
+Share what you learned from the website ONCE, then ask for missing fields.
+Example: "From your website, I see this is a real estate project in Bangalore. Which platform — Google Ads or Meta?"
+After this first mention, do NOT repeat the website context. Keep subsequent messages short and focused on the next field only.
+Only call update_ad_plan with fields the user has explicitly provided or confirmed.
+
+### CORRECTION HANDLING
+- User says "actually X" → update field, acknowledge in 1 line, keep moving
+- "Updated! [field] is now [value]." — then continue with next step
+- Never re-confirm what was just corrected
 
 ### INPUT NORMALIZATION
 
-**Target leads formats (Google):**
-- Numbers: "50", "100", "200"
-- With words: "50 leads", "100 conversions", "I want 20 leads"
-- Approximate: "around 50" → 50, "about 100 leads" → 100
+**Target leads (Google):** "50", "50 leads", "around 100" → extract number
+**Budget:** "5k" → 5000, "5 lakh" → 500000, "$5,000" → 5000. Budget is DAILY.
+If user says total budget, you MUST divide by durationDays and save the DAILY amount.
+Example: "60k total" + 60 days → update_ad_plan({{"budget": "1000"}}) and reply "That's ₹1,000/day over 60 days."
+If user clarifies "its total" after giving a number, recalculate: original_amount / durationDays = daily budget.
+If duration unknown, ask for it first before accepting the budget.
+ALWAYS confirm the calculated daily amount explicitly in your reply.
+**Duration:** "2 weeks" → 14, "1 month" → 30, "7 days" → 7
+**URL:** Accept any domain pattern. Tool adds "https://" if missing.
+**Product:** Accept as-is, preserve capitalization.
 
-**Budget formats (Meta, or Google override):**
-Budget is the DAILY budget (not total). Ask: "What's your daily advertising budget?"
-If user says "50k total for 30 days", divide by durationDays to get daily. If duration unknown, ask for it first.
-- Numbers: "5000", "10000"
-- With k/K: "5k", "10K", "2.5k"
-- With m/M: "5m", "1.5m"
-- With currency: "$5000", "₹5000", "$5,000"
-- Words: "five thousand", "ten thousand"
-- Indian: "5 lakh", "2 crore"
-
-**Duration formats to extract:**
-- Numbers: "7", "14", "30"
-- With days: "7 days", "14 days"
-- With weeks: "1 week", "2 weeks" (convert: 1 week = 7 days)
-- With months: "1 month", "2 months" (convert: 1 month = 30 days)
-- With prepositions: "For 10 days" = 10, "For 2 weeks" = 14
-
-**Website URL:**
-- Accept any domain pattern: "example.com", "www.example.com", "https://example.com"
-- Tool will add "https://" if missing
-
-**Business Name:**
-- Accept as-is, preserve capitalization
-- Extract from patterns like "campaign for X", "create a campaign for X"
-- If vague ("my business"), ask for actual name
-
-### EXTRACTION EXAMPLES
-
-User: "google"
-→ update_ad_plan({{"platform": "google"}})
-→ "Google Ads it is! What's your business name?"
-
-User: "I want to advertise on facebook"
-→ update_ad_plan({{"platform": "meta"}})
-→ "Meta Ads — great choice! What's your business name?"
-
-User: "50 leads" (platform is google)
-→ update_ad_plan({{"targetLeads": 50}})
-→ "Got it! Targeting 50 leads. We'll estimate the budget for you."
-
-User: "I want around 100 conversions" (platform is google)
-→ update_ad_plan({{"targetLeads": 100}})
-→ "100 leads — noted! How long should the campaign run?"
-
-User: "5k" (platform is meta)
-→ update_ad_plan({{"budget": "5k"}})
-→ "Got it! Daily budget of ₹5,000 noted. What's your business name?"
-
-User: "budget is 10k" (platform is google)
-→ update_ad_plan({{"budget": "10k"}})
-→ "Daily budget of ₹10,000 noted! How long should the campaign run?"
-
-User: "TechCorp and example.com"
-→ update_ad_plan({{"businessName": "TechCorp", "websiteURL": "example.com"}})
-→ "Perfect! I have your business name and website. How many leads do you want?"
-
-User: "2 weeks"
-→ update_ad_plan({{"durationDays": 14}})
-→ "Great! Campaign duration set to 14 days."
-
-User: "I run TechCorp, techcorp.com, 50 leads, 2 weeks on google"
-→ update_ad_plan({{"platform": "google", "businessName": "TechCorp", "websiteURL": "techcorp.com", "targetLeads": 50, "durationDays": 14}})
-
-User: "hi I want to create a campaign for cityville"
-→ update_ad_plan({{"businessName": "cityville"}})
-→ "Hello! Got it - creating campaign for cityville. Which platform — Google or Meta?"
+### PLATFORM EXTRACTION
+- "google", "google ads" → "google"
+- "meta", "facebook", "fb", "instagram" → "meta"
 
 ### VALIDATION HANDLING
-
-If tool validation fails on ONE field:
-1. DO NOT discard valid fields
-2. Call tool again with ONLY valid fields
-3. Ask user to correct the failed field
-
-Example:
-User: "Business is FitZone, mysite,com, 50 leads, 2 weeks"
-First: update_ad_plan({{"businessName": "FitZone", "websiteURL": "mysite,com", "targetLeads": 50, "durationDays": 14}})
-Error on websiteURL
-Second: update_ad_plan({{"businessName": "FitZone", "targetLeads": 50, "durationDays": 14}})
-Response: "I have your business name, target leads, and duration. Could you provide a valid website URL like mysite.com?"
+If tool validation fails on a field:
+1. Keep valid fields
+2. Ask user to correct only the failed field
+3. Don't discard what worked
 
 ### RESPONSE STYLE
-- Be conversational and concise (2-3 sentences)
-- After tool call, acknowledge what you got and ask for next missing field
-- Match user's pace
-- Mention progress naturally using the [CONTEXT] info provided:
-  - "Great, that's 3 of 5! Now, how many leads are you targeting?"
-  - "Almost done — just need your campaign duration."
-  - "Last one! How long should the campaign run?"
-- If user corrects a previously provided field, acknowledge the update:
-  - "Updated! Your business name is now FitZone instead of FitZone Pro."
+- Conversational, concise (1-2 sentences max)
+- ALWAYS acknowledge what the user just provided before asking the next question. Example: "45 days, got it! How many leads are you targeting?"
+- NEVER repeat website/scrape context the user has already seen. Mention it ONCE when scrape data first arrives, then move on.
+- Max 2 questions per message
+- Never count fields ("3 of 5!") — focus on what matters next
+- NEVER use markdown formatting — no **bold**, no *italic*, no bullet lists, no headers. Write plain conversational text only.
 
 ### TODAY'S DATE
-Current date is {TODAY} - use for any date calculations.
+Current date is {TODAY} — use for any date calculations.

--- a/services/adzump_session_bridge.py
+++ b/services/adzump_session_bridge.py
@@ -1,0 +1,272 @@
+"""Bridge ds sessions ↔ nocode-ai adzump sessions.
+
+Until the adzump migration is complete, the chat happens in nocode-ai
+(adzump agent) but downstream APIs (keywords, campaign create, ads) still
+run in ds and expect a populated `sessions[id]["campaign_data"]`. This
+module pulls the adzump session from nocode-ai and seeds a ds session.
+
+Flow:
+1. UI / caller has an adzump session id (e.g. "SYSTEM_165db4b8") and a JWT.
+2. Calls POST /api/ds/chat/from-adzump-session/{id} on ds with auth headers.
+3. ds calls GET {gateway}/marketingai/{clientCode}/api/ai/adzump/sessions/{id}
+   forwarding the user's auth — same trust boundary as the original request.
+4. ds parses session.context_json, maps adzump fields → ds campaign_data,
+   creates a ds session, returns the new ds session_id.
+
+Mapping nocode-ai → ds (see CampaignData in models/campaign_data_model.py
+plus actual usages in chat_service / google_keywords_service):
+
+| ds key              | adzump source                                |
+|---------------------|----------------------------------------------|
+| businessName        | product_data.product_name                    |
+| websiteURL          | product_profile.url or pages_analyzed[0]     |
+| budget              | campaign_spec.budget (digits extracted)      |
+| durationDays        | campaign_spec.duration (digits extracted)    |
+| loginCustomerId     | campaign_spec.parent_account                 |
+| customerId          | campaign_spec.account                        |
+| locations           | [_location_meta.address] or [spec.location]  |
+| platform            | campaign_spec.platform                       |
+| productSummary      | product_data.summary                         |
+| competitors         | competitor_analysis.competitors              |
+| adzumpProductId     | session.context["product_id"]                |
+| adzumpSessionId     | source session id                            |
+
+Meta-only fields (fb_page, ig_page) are passed through under their adzump
+keys but not mapped to a typed CampaignData field — ds's Meta path can
+read them off the dict directly when needed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from structlog import get_logger  # type: ignore
+
+from core.infrastructure.context import auth_context
+from exceptions.custom_exceptions import BusinessValidationException
+from oserver.services.base_api_service import BaseAPIService
+from oserver.utils.helpers import get_base_url
+from services.session_manager import sessions
+
+logger = get_logger(__name__)
+
+# AppCode under which adzump records live in nocode-ai (matches the gateway
+# routing prefix `/marketingai/{clientCode}/...`).
+ADZUMP_APP_CODE = "marketingai"
+
+
+# ── Outbound: fetch adzump session from nocode-ai ────────────────────────
+
+
+async def _fetch_adzump_session(
+    adzump_session_id: str,
+    *,
+    access_token: str,
+    client_code: str,
+    x_forwarded_host: str = "",
+    x_forwarded_port: str = "",
+) -> dict[str, Any]:
+    """GET the adzump session detail through the gateway.
+
+    Returns the parsed JSON response (which has shape
+    ``{session, history, total_history, limit, offset}``).
+    Raises BusinessValidationException on HTTP error or empty response.
+    """
+    base = get_base_url().rstrip("/")
+    url = f"{base}/{ADZUMP_APP_CODE}/{client_code}/api/ai/adzump/sessions/{adzump_session_id}"
+    headers = {
+        "authorization": access_token,
+        "clientCode": client_code,
+        "appCode": ADZUMP_APP_CODE,
+        "X-Forwarded-Host": x_forwarded_host or "",
+        "X-Forwarded-Port": x_forwarded_port or "",
+        "content-type": "application/json",
+    }
+
+    client = BaseAPIService()
+    try:
+        result = await client.request("GET", url, headers=headers)
+    except Exception as e:
+        logger.warning("adzump_session_fetch_failed",
+                       url=url, err=str(e)[:200])
+        raise BusinessValidationException(
+            f"Failed to fetch adzump session {adzump_session_id}: {e}",
+        ) from e
+
+    if not isinstance(result, dict) or "session" not in result:
+        raise BusinessValidationException(
+            f"Unexpected response shape from nocode-ai: {type(result).__name__}",
+        )
+    return result
+
+
+# ── Mapping: adzump context → ds campaign_data ────────────────────────────
+
+
+_DIGITS_RE = re.compile(r"\d+")
+
+
+def _extract_int(value: Any) -> Optional[int]:
+    """Pull the first integer out of a possibly-formatted string.
+
+    "60 days" → 60, "₹25,000/day" → 25000, 30 → 30, None → None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    digits = "".join(_DIGITS_RE.findall(str(value)))
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
+
+
+def _resolve_url(context: dict) -> str:
+    profile = context.get("product_profile") or {}
+    if profile.get("url"):
+        return str(profile["url"])
+    product = context.get("product_data") or {}
+    pages = product.get("pages_analyzed") or []
+    if pages:
+        return str(pages[0])
+    return ""
+
+
+def _resolve_locations(context: dict) -> list[str]:
+    meta = context.get("_location_meta") or {}
+    if meta.get("address"):
+        return [str(meta["address"])]
+    spec = context.get("campaign_spec") or {}
+    if spec.get("location"):
+        return [str(spec["location"])]
+    return []
+
+
+def _strip_account_id(value: Any) -> Optional[str]:
+    """Account ids should be stored without dashes/whitespace."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    return re.sub(r"[\s\-]", "", s) or None
+
+
+def map_adzump_context_to_campaign_data(context: dict) -> dict:
+    """Pure transform: adzump session.context dict → ds campaign_data dict."""
+    product = context.get("product_data") or {}
+    spec = context.get("campaign_spec") or {}
+    competitive = context.get("competitor_analysis") or {}
+    location_meta = context.get("_location_meta") or {}
+    account_names = context.get("account_names") or {}
+
+    return {
+        # Core CampaignData fields (typed in models/campaign_data_model.py)
+        "businessName": product.get("product_name") or "",
+        "websiteURL": _resolve_url(context),
+        "budget": str(_extract_int(spec.get("budget")) or "") or None,
+        "durationDays": _extract_int(spec.get("duration")),
+        "loginCustomerId": _strip_account_id(spec.get("parent_account")),
+        "customerId": _strip_account_id(spec.get("account")),
+
+        # Extras consumed by other ds services (chat / external_link / ...)
+        "platform": spec.get("platform"),
+        "locations": _resolve_locations(context),
+        "productSummary": product.get("summary") or "",
+        "businessType": product.get("business_type") or "",
+        "competitors": competitive.get("competitors") or [],
+        "accountNames": account_names,
+
+        # Meta-only — passed through by name; ds Meta path reads as needed
+        "fbPageId": _strip_account_id(spec.get("fb_page")),
+        "igAccountId": _strip_account_id(spec.get("ig_page")),
+
+        # Provenance — useful for debugging / re-syncing
+        "adzumpProductId": context.get("product_id"),
+        "adzumpSessionId": context.get("_adzump_session_id_seed", ""),
+        "adzumpLocationLat": location_meta.get("lat"),
+        "adzumpLocationLng": location_meta.get("lng"),
+    }
+
+
+# ── ds session creation ──────────────────────────────────────────────────
+
+
+def _create_ds_session(campaign_data: dict, client_code: str) -> str:
+    """Create a ds session in the in-memory `sessions` dict and return its id.
+
+    Mirrors the shape `chat_service.start_session()` writes so that
+    downstream services (chat_service / google_keywords_service /
+    create_campaign_service / ads_service) all read what they expect.
+    """
+    session_id = str(uuid.uuid4())
+    sessions[session_id] = {
+        "chat_history": [],
+        "last_activity": datetime.now(timezone.utc),
+        "campaign_data": campaign_data,
+        "status": "ready",  # not "in_progress" — adzump already collected the data
+        "mcc_options": [],
+        "customer_options": [],
+        "client_code": client_code,
+    }
+    logger.info("adzump_bridge_session_created",
+                session_id=session_id, client_code=client_code,
+                businessName=campaign_data.get("businessName"))
+    return session_id
+
+
+# ── Public entry point ────────────────────────────────────────────────────
+
+
+async def create_session_from_adzump(adzump_session_id: str) -> dict:
+    """Pull the adzump session, map it, create a ds session.
+
+    Reads auth from the request-scoped `auth_context` ContextVar (set by ds's
+    middleware on incoming requests). Returns
+    ``{"session_id": "...", "campaign_data": {...}, "source_adzump_session_id": "..."}``.
+    """
+    if not adzump_session_id:
+        raise BusinessValidationException("adzump_session_id is required")
+
+    access_token = auth_context.access_token
+    client_code = auth_context.client_code
+    if not access_token or not client_code:
+        raise BusinessValidationException(
+            "Missing auth context (access_token / client_code). "
+            "Caller must include Authorization + clientCode headers.",
+        )
+
+    payload = await _fetch_adzump_session(
+        adzump_session_id,
+        access_token=access_token,
+        client_code=client_code,
+        x_forwarded_host=auth_context.x_forwarded_host,
+        x_forwarded_port=auth_context.x_forwarded_port,
+    )
+
+    raw_session = payload.get("session") or {}
+    context_json = raw_session.get("context_json") or "{}"
+    try:
+        context = json.loads(context_json) if isinstance(context_json, str) else (context_json or {})
+    except (ValueError, json.JSONDecodeError) as e:
+        raise BusinessValidationException(
+            f"Adzump session context_json is not valid JSON: {e}",
+        ) from e
+
+    # Stash the source id in context before mapping so it lands in
+    # campaign_data.adzumpSessionId for traceability.
+    context["_adzump_session_id_seed"] = adzump_session_id
+
+    campaign_data = map_adzump_context_to_campaign_data(context)
+    ds_session_id = _create_ds_session(campaign_data, client_code)
+
+    return {
+        "session_id": ds_session_id,
+        "campaign_data": campaign_data,
+        "source_adzump_session_id": adzump_session_id,
+    }

--- a/services/geo_target_service.py
+++ b/services/geo_target_service.py
@@ -21,8 +21,8 @@ class GeoTargetService:
     DEFAULT_RADIUS_KM = 15
 
     # Grid configuration
-    GRID_STEP_KM = 5  # 5km steps
-    MAX_GRID_POINTS = 40  # Safety cap
+    GRID_STEP_KM = 3  # 3km steps for better pin code coverage
+    MAX_GRID_POINTS = 80  # Safety cap
     MAX_CONCURRENT_GEOCODE = 10  # Parallel requests
     MIN_DISTANCE_KM = 2.0  # Deduplication threshold
 
@@ -197,34 +197,17 @@ class GeoTargetService:
                             if "country" in types:
                                 country_code = component.get("short_name", "IN")
 
-                    # Define target types in priority order
-                    target_types = [
-                        "sublocality_level_1",
-                        "sublocality",
-                        "neighborhood",
-                        "locality",
-                    ]
-
-                    # Find the best locality/neighborhood and also a parent city
-                    best_component = None
+                    # Extract postal code from address components
+                    postal_code = None
                     parent_city = ""
-                    best_res = None
 
                     for res in results:
                         for component in res.get("address_components", []):
                             comp_types = component.get("types", [])
 
-                            # Check if this could be our target
-                            if not best_component:
-                                matched_type = next(
-                                    (t for t in target_types if t in comp_types), None
-                                )
-                                if matched_type:
-                                    best_component = component
-                                    best_component["matched_type"] = matched_type
-                                    best_res = res
+                            if "postal_code" in comp_types and not postal_code:
+                                postal_code = component.get("long_name")
 
-                            # Check if this is a good parent city (Locality/Admin Area 2)
                             if not parent_city:
                                 if (
                                     "locality" in comp_types
@@ -232,19 +215,17 @@ class GeoTargetService:
                                 ):
                                     parent_city = component.get("long_name", "")
 
-                    if best_component and best_res:
-                        name = best_component.get("long_name")
-                        # Add parent city if it's different from the name itself
-                        search_name = name
-                        if parent_city and parent_city.lower() != name.lower():
-                            search_name = f"{name}, {parent_city}"
+                    if postal_code:
+                        search_name = postal_code
+                        if parent_city:
+                            search_name = f"{postal_code}, {parent_city}"
 
-                        geo = best_res.get("geometry", {}).get("location", {})
+                        geo = results[0].get("geometry", {}).get("location", {})
                         return {
                             "name": search_name,
                             "lat": geo.get("lat", point["lat"]),
                             "lng": geo.get("lng", point["lng"]),
-                            "type": best_component["matched_type"],
+                            "type": "postal_code",
                         }
 
                     return None
@@ -607,11 +588,11 @@ class GeoTargetService:
 
         # Pick best match per term
         for term_lower, matches in by_search_term.items():
-            # Priority: Neighborhood > Sublocality > Postal Code
+            # Priority: Postal Code > Neighborhood > Sublocality
             score_map = {
-                "Neighborhood": 1,
-                "Sublocality": 2,
-                "Postal Code": 3,
+                "Postal Code": 1,
+                "Neighborhood": 2,
+                "Sublocality": 3,
             }
 
             matches.sort(key=lambda x: score_map.get(x["target_type"], 10))

--- a/services/openai_client.py
+++ b/services/openai_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import AsyncIterator
 from functools import lru_cache
 from openai import AsyncOpenAI
 import os
@@ -22,6 +23,21 @@ async def chat_completion(messages: list, model: str = "gpt-4.1", **kwargs):
             model=model, messages=messages, **kwargs
         )
         return response
+
+
+async def chat_completion_stream(
+    messages: list, model: str = "gpt-4.1", **kwargs
+) -> AsyncIterator[str]:
+    """Stream chat completion, yielding content delta strings."""
+    async with _semaphore:
+        client = get_client()
+        stream = await client.chat.completions.create(
+            model=model, messages=messages, stream=True, **kwargs
+        )
+        async for chunk in stream:
+            delta = chunk.choices[0].delta if chunk.choices else None
+            if delta and delta.content:
+                yield delta.content
 
 
 async def generate_embeddings(

--- a/services/screenshot_service.py
+++ b/services/screenshot_service.py
@@ -1,3 +1,5 @@
+import warnings
+
 from structlog import get_logger  # type: ignore
 from typing import Optional
 from fastapi import HTTPException
@@ -13,6 +15,12 @@ from oserver.models.storage_request_model import (
     StorageReadRequest,
     StorageUpdateWithPayload,
     StorageRequestWithPayload,
+)
+
+warnings.warn(
+    "screenshot_service is deprecated. Use agents.scrape.scrape_agent instead.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 logger = get_logger(__name__)

--- a/tests/chatv2/test_chatv2_assistant.py
+++ b/tests/chatv2/test_chatv2_assistant.py
@@ -1,0 +1,827 @@
+"""
+Automated Test Suite for ChatV2 Campaign Assistant
+Comprehensive tests for all scenarios
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+import requests
+import os
+import json
+import time
+from datetime import datetime
+from typing import Dict, Any
+from colorama import init, Fore, Style  # type: ignore[import-untyped]
+
+init(autoreset=True)
+
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8000")
+CLIENT_CODE = os.getenv("CLIENT_CODE", "TEST_CLIENT")
+
+
+class _TestStats:
+    def __init__(self):
+        self.total = 0
+        self.passed = 0
+        self.failed = 0
+        self.failed_tests = []
+
+
+stats = _TestStats()
+
+
+def print_header(text: str):
+    print(f"\n{Fore.CYAN}{'='*80}")
+    print(f"{Fore.CYAN}{text:^80}")
+    print(f"{Fore.CYAN}{'='*80}{Style.RESET_ALL}")
+
+
+def print_test_name(name: str):
+    print(f"\n{Fore.YELLOW}>> TEST: {name}{Style.RESET_ALL}")
+
+
+def print_step(step_num: int, message: str):
+    print(f"{Fore.WHITE}  Step {step_num}: {message}{Style.RESET_ALL}")
+
+
+def print_success(message: str):
+    print(f"{Fore.GREEN}  OK: {message}{Style.RESET_ALL}")
+
+
+def print_error(message: str):
+    print(f"{Fore.RED}  FAIL: {message}{Style.RESET_ALL}")
+
+
+def print_response(response: Dict):
+    print(f"{Fore.MAGENTA}  Response: {json.dumps(response, indent=2)}{Style.RESET_ALL}")
+
+
+class ChatV2TestClient:
+    """Client for testing ChatV2 API"""
+
+    def __init__(self, base_url: str = BASE_URL, client_code: str = CLIENT_CODE):
+        self.base_url = base_url
+        self.client_code = client_code
+        self.session_id: str | None = None
+
+    def start_session(self) -> str:
+        response = requests.post(f"{self.base_url}/api/ds/chatv2/start-session")
+        response.raise_for_status()
+        session_id: str = response.json()["session_id"]
+        self.session_id = session_id
+        return session_id
+
+    def send_message(self, message: str) -> Dict[str, Any]:
+        # TODO: update to use /stream SSE endpoint (non-stream endpoint removed)
+        if not self.session_id:
+            raise ValueError("No active session. Call start_session() first.")
+
+        response = requests.post(
+            f"{self.base_url}/api/ds/chatv2/{self.session_id}",
+            params={"message": message},
+            headers={
+                "content-type": "application/json",
+                "clientCode": self.client_code,
+            },
+        )
+
+        if response.status_code != 200:
+            try:
+                return response.json()
+            except json.JSONDecodeError:
+                return {
+                    "status": "error",
+                    "message": f"HTTP {response.status_code}",
+                    "details": response.text,
+                }
+
+        return response.json()
+
+    def get_session(self) -> Dict[str, Any]:
+        if not self.session_id:
+            return {"error": "No active session"}
+        response = requests.get(f"{self.base_url}/api/ds/chatv2/{self.session_id}")
+        return response.json()
+
+    def end_session(self) -> Dict[str, Any]:
+        if not self.session_id:
+            return {"error": "No active session"}
+
+        response = requests.post(
+            f"{self.base_url}/api/ds/chatv2/end-session/{self.session_id}",
+            headers={"content-type": "application/json"},
+        )
+
+        self.session_id = None
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return {"error": f"HTTP {response.status_code}", "details": response.text}
+
+
+def assert_status(actual: str, expected: str, test_name: str):
+    stats.total += 1
+    if actual == expected:
+        print_success(f"Status: {actual} (Expected: {expected})")
+        stats.passed += 1
+        return True
+    else:
+        print_error(f"Status mismatch! Got: {actual}, Expected: {expected}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+        return False
+
+
+def assert_contains(text: str, substring: str, description: str, test_name: str):
+    stats.total += 1
+    if substring.lower() in text.lower():
+        print_success(f"{description}: Contains '{substring}'")
+        stats.passed += 1
+        return True
+    else:
+        print_error(f"{description}: Does NOT contain '{substring}'")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+        return False
+
+
+def assert_field_extracted(response: Dict, field_name: str, test_name: str):
+    stats.total += 1
+    collected = response.get("collected_data", {})
+    if collected and field_name in collected:
+        print_success(f"Field extracted: {field_name}")
+        stats.passed += 1
+        return True
+    else:
+        print_error(f"Field NOT extracted: {field_name}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+        return False
+
+
+def assert_progress(response: Dict, expected_progress: str, test_name: str):
+    stats.total += 1
+    actual = response.get("progress", "")
+    if actual == expected_progress:
+        print_success(f"Progress: {actual}")
+        stats.passed += 1
+        return True
+    else:
+        print_error(f"Progress mismatch! Got: {actual}, Expected: {expected_progress}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+        return False
+
+
+def assert_reply_not_empty(response: Dict, test_name: str):
+    """Assert that reply is not empty - critical for continuation responses"""
+    stats.total += 1
+    reply = response.get("reply", "")
+    if reply and reply.strip():
+        print_success(f"Reply not empty: '{reply[:50]}...'")
+        stats.passed += 1
+        return True
+    else:
+        print_error("Reply is EMPTY (should have content)")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+        return False
+
+
+# CATEGORY 1: GREETING TESTS
+
+
+def test_simple_greeting():
+    test_name = "Simple Greeting"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send: 'hi'")
+    response = client.send_message("hi")
+    print_response(response)
+
+    assert_status(response.get("status"), "in_progress", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    client.end_session()
+
+
+def test_greeting_with_details():
+    test_name = "Greeting with Details"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send: 'Hello, I run TechCorp, budget is 10k'")
+    response = client.send_message("Hello, I run TechCorp, budget is 10k")
+    print_response(response)
+
+    assert_status(response.get("status"), "in_progress", test_name)
+    assert_field_extracted(response, "businessName", test_name)
+    assert_field_extracted(response, "budget", test_name)
+
+    client.end_session()
+
+
+# CATEGORY 2: ALL-AT-ONCE INPUT
+
+
+def test_all_at_once_standard():
+    test_name = "All-at-Once Standard"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send all details at once")
+    response = client.send_message(
+        "Setup campaign for Fresh Bakery, website is https://freshbakery.com, budget 5000, 7 days"
+    )
+    print_response(response)
+
+    # Should have all fields and move to MCC selection
+    assert_field_extracted(response, "businessName", test_name)
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_field_extracted(response, "budget", test_name)
+    assert_field_extracted(response, "durationDays", test_name)
+
+    client.end_session()
+
+
+def test_all_at_once_informal():
+    test_name = "All-at-Once Informal"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send: 'I run Pizza Palace, pizzapalace.com, 15k budget, 2 weeks'")
+    response = client.send_message(
+        "I run Pizza Palace, pizzapalace.com, 15k budget, 2 weeks"
+    )
+    print_response(response)
+
+    assert_field_extracted(response, "businessName", test_name)
+    assert_field_extracted(response, "budget", test_name)
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_field_extracted(response, "durationDays", test_name)
+
+    client.end_session()
+
+
+# CATEGORY 3: STEP-BY-STEP INPUT
+
+
+def test_step_by_step_flow():
+    test_name = "Step-by-Step Flow"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send: 'My business is Urban Fitness'")
+    response = client.send_message("My business is Urban Fitness")
+    print_response(response)
+    assert_field_extracted(response, "businessName", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(2, "Send: 'urbanfitness.com'")
+    response = client.send_message("urbanfitness.com")
+    print_response(response)
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(3, "Send: '7500'")
+    response = client.send_message("7500")
+    print_response(response)
+    assert_field_extracted(response, "budget", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(4, "Send: '14 days'")
+    response = client.send_message("14 days")
+    print_response(response)
+    assert_field_extracted(response, "durationDays", test_name)
+
+    client.end_session()
+
+
+def test_random_order():
+    """Test fields provided in random order"""
+    test_name = "Random Order"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Budget first")
+    response = client.send_message("My budget is 20000")
+    assert_field_extracted(response, "budget", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(2, "Duration second")
+    response = client.send_message("For 10 days")
+    assert_field_extracted(response, "durationDays", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(3, "Website third")
+    response = client.send_message("Website: techsolutions.io")
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(4, "Business name last")
+    response = client.send_message("Business name is Tech Solutions")
+    assert_field_extracted(response, "businessName", test_name)
+
+    client.end_session()
+
+
+def test_user_provides_different_field():
+    """CRITICAL: When AI asks for business name but user provides budget, should acknowledge and continue"""
+    test_name = "User Provides Different Field (Critical)"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send greeting to start")
+    response = client.send_message("Hi, I want to create a campaign")
+    print_response(response)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(2, "AI asked for business name, but send budget instead")
+    response = client.send_message("my budget is 5k")
+    print_response(response)
+
+    # CRITICAL: Reply should NOT be empty
+    assert_reply_not_empty(response, test_name)
+    assert_field_extracted(response, "budget", test_name)
+
+    client.end_session()
+
+
+# CATEGORY 4: INPUT NORMALIZATION
+
+
+def test_budget_normalization():
+    """Test that various budget formats are accepted and extracted"""
+    test_name = "Budget Normalization"
+    print_test_name(test_name)
+
+    test_cases = ["5k", "10K", "2.5k", "$5000", "15000"]
+
+    for input_val in test_cases:
+        client = ChatV2TestClient()
+        client.start_session()
+
+        print_step(1, f"Testing budget: {input_val}")
+        response = client.send_message(f"budget is {input_val}")
+
+        # Just verify budget was extracted (actual value normalization happens internally)
+        assert_field_extracted(response, "budget", f"{test_name} ({input_val})")
+        assert_reply_not_empty(response, f"{test_name} ({input_val})")
+
+        client.end_session()
+        time.sleep(0.3)
+
+
+def test_url_normalization():
+    """Test that various URL formats are accepted and extracted"""
+    test_name = "URL Normalization"
+    print_test_name(test_name)
+
+    test_cases = ["google.com", "www.google.com", "https://google.com"]
+
+    for input_val in test_cases:
+        client = ChatV2TestClient()
+        client.start_session()
+
+        print_step(1, f"Testing URL: {input_val}")
+        response = client.send_message(f"My website is {input_val}")
+
+        # Just verify URL was extracted (actual normalization happens internally)
+        assert_field_extracted(response, "websiteURL", f"{test_name} ({input_val})")
+        assert_reply_not_empty(response, f"{test_name} ({input_val})")
+
+        client.end_session()
+        time.sleep(0.3)
+
+
+# CATEGORY 5: VALIDATION & ERROR HANDLING
+
+
+def test_invalid_url():
+    test_name = "Invalid URL"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send invalid URL: 'not-a-valid-url@@@'")
+    response = client.send_message("My site is not-a-valid-url@@@")
+    print_response(response)
+
+    collected = response.get("collected_data") or {}
+    stats.total += 1
+    if "websiteURL" not in collected:
+        print_success("Invalid URL not extracted")
+        stats.passed += 1
+    else:
+        print_error("Invalid URL was extracted (should not be)")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    assert_reply_not_empty(response, test_name)
+
+    client.end_session()
+
+
+def test_non_existent_domain():
+    test_name = "Non-Existent Domain"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send non-existent domain: 'svdgsvfgdsvfg.com'")
+    response = client.send_message("My website is svdgsvfgdsvfg.com")
+    print_response(response)
+
+    collected = response.get("collected_data") or {}
+    stats.total += 1
+    if "websiteURL" not in collected:
+        print_success("Non-existent domain correctly rejected")
+        stats.passed += 1
+    else:
+        print_error("Non-existent domain was accepted")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    client.end_session()
+
+
+def test_valid_domain():
+    test_name = "Valid Domain"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send valid domain: 'https://www.google.com'")
+    response = client.send_message("My website is https://www.google.com")
+    print_response(response)
+
+    assert_field_extracted(response, "websiteURL", test_name)
+
+    client.end_session()
+
+
+# CATEGORY 6: EDGE CASES
+
+
+def test_unrelated_query():
+    test_name = "Unrelated Query"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send unrelated query")
+    response = client.send_message("What's the weather today?")
+    print_response(response)
+
+    assert_reply_not_empty(response, test_name)
+
+    # No fields should be extracted
+    collected = response.get("collected_data") or {}
+    stats.total += 1
+    if not collected or len(collected) == 0:
+        print_success("No fields extracted from unrelated query")
+        stats.passed += 1
+    else:
+        print_error(f"Fields extracted from unrelated query: {collected}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    client.end_session()
+
+
+def test_mixed_valid_invalid():
+    test_name = "Mixed Valid and Invalid"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send: 'Business is FitZone, mysite,com, 6k, 2 weeks'")
+    response = client.send_message("Business is FitZone, mysite,com, 6k, 2 weeks")
+    print_response(response)
+
+    collected = response.get("collected_data") or {}
+
+    stats.total += 3
+    if "businessName" in collected:
+        print_success("businessName extracted")
+        stats.passed += 1
+    else:
+        print_error("businessName not extracted")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    if "budget" in collected:
+        print_success("budget extracted")
+        stats.passed += 1
+    else:
+        print_error("budget not extracted")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    if "websiteURL" not in collected:
+        print_success("Invalid URL correctly rejected")
+        stats.passed += 1
+    else:
+        print_error("Invalid URL was accepted")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    client.end_session()
+
+
+def test_empty_input():
+    test_name = "Empty Input"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send empty message")
+    response = client.send_message("   ")
+    print_response(response)
+
+    stats.total += 1
+    if response.get("status") in ["in_progress", "error"]:
+        print_success("Empty input handled gracefully")
+        stats.passed += 1
+    else:
+        print_error(f"Unexpected status for empty input: {response.get('status')}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    client.end_session()
+
+
+def test_long_business_name():
+    test_name = "Long Business Name"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    long_name = "The International Corporation for Advanced Technology Solutions and Digital Marketing Services"
+
+    print_step(1, f"Send long business name ({len(long_name)} chars)")
+    response = client.send_message(f"Business name is {long_name}")
+    print_response(response)
+
+    # Verify field was extracted and reply mentions the name
+    assert_field_extracted(response, "businessName", test_name)
+    assert_contains(response.get("reply", ""), "International", "Reply contains business name", test_name)
+
+    client.end_session()
+
+
+def test_special_characters():
+    test_name = "Special Characters"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    special_name = "Joe's Cafe & Bakery"
+
+    print_step(1, "Send business name with special characters")
+    response = client.send_message(f"Business is {special_name}")
+    print_response(response)
+
+    # Verify field was extracted and reply mentions the name
+    assert_field_extracted(response, "businessName", test_name)
+    assert_contains(response.get("reply", ""), "Joe", "Reply contains business name", test_name)
+
+    client.end_session()
+
+
+# CATEGORY 7: SESSION MANAGEMENT
+
+
+def test_invalid_session():
+    test_name = "Invalid Session"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.session_id = "invalid-session-id-12345"
+
+    print_step(1, "Send message with invalid session")
+    response = client.send_message("hi")
+    print_response(response)
+
+    stats.total += 1
+    if "error" in str(response).lower() or "invalid" in str(response).lower() or response.get("detail"):
+        print_success("Invalid session rejected correctly")
+        stats.passed += 1
+    else:
+        print_error(f"Invalid session not handled: {response}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+
+def test_session_persistence():
+    test_name = "Session Persistence"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+    client.start_session()
+
+    print_step(1, "Send business name")
+    response = client.send_message("Business is PersistCo")
+    assert_field_extracted(response, "businessName", test_name)
+
+    print_step(2, "Send website (should remember business name)")
+    response = client.send_message("Website is persistco.com")
+    collected = response.get("collected_data") or {}
+
+    stats.total += 1
+    if "businessName" in collected and "websiteURL" in collected:
+        print_success("Session persisted both fields")
+        stats.passed += 1
+    else:
+        print_error(f"Session didn't persist fields: {collected}")
+        stats.failed += 1
+        stats.failed_tests.append(test_name)
+
+    client.end_session()
+
+
+# CATEGORY 8: END-TO-END FLOWS
+
+
+def test_e2e_step_by_step():
+    test_name = "E2E Step by Step"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+
+    print_step(1, "Start session")
+    client.start_session()
+
+    print_step(2, "Greeting")
+    response = client.send_message("hi")
+    assert_reply_not_empty(response, test_name)
+
+    print_step(3, "Business name")
+    response = client.send_message("My business is StyleCo")
+    assert_field_extracted(response, "businessName", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(4, "Website")
+    response = client.send_message("styleco.com")
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(5, "Budget")
+    response = client.send_message("5k budget")
+    assert_field_extracted(response, "budget", test_name)
+    assert_reply_not_empty(response, test_name)
+
+    print_step(6, "Duration")
+    response = client.send_message("2 weeks")
+    assert_field_extracted(response, "durationDays", test_name)
+
+    print_step(7, "End session")
+    client.end_session()
+
+
+def test_e2e_all_at_once():
+    test_name = "E2E All at Once"
+    print_test_name(test_name)
+
+    client = ChatV2TestClient()
+
+    print_step(1, "Start session")
+    client.start_session()
+
+    print_step(2, "Provide all details")
+    response = client.send_message(
+        "I run TechHub, techhub.io, 10000 budget, 1 week"
+    )
+    print_response(response)
+
+    assert_field_extracted(response, "businessName", test_name)
+    assert_field_extracted(response, "websiteURL", test_name)
+    assert_field_extracted(response, "budget", test_name)
+    assert_field_extracted(response, "durationDays", test_name)
+
+    print_step(3, "End session")
+    client.end_session()
+
+
+# TEST RUNNER
+
+
+def run_all_tests():
+    print_header("CHATV2 ASSISTANT - AUTOMATED TEST SUITE")
+    print(f"{Fore.WHITE}Testing API at: {BASE_URL}{Style.RESET_ALL}")
+    print(f"{Fore.WHITE}Start time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}{Style.RESET_ALL}\n")
+
+    try:
+        # Category 1: Greetings
+        print_header("CATEGORY 1: GREETING TESTS")
+        test_simple_greeting()
+        test_greeting_with_details()
+
+        # Category 2: All-at-once
+        print_header("CATEGORY 2: ALL-AT-ONCE INPUT")
+        test_all_at_once_standard()
+        test_all_at_once_informal()
+
+        # Category 3: Step-by-step
+        print_header("CATEGORY 3: STEP-BY-STEP INPUT")
+        test_step_by_step_flow()
+        test_random_order()
+        test_user_provides_different_field()
+
+        # Category 4: Normalization
+        print_header("CATEGORY 4: INPUT NORMALIZATION")
+        test_budget_normalization()
+        test_url_normalization()
+
+        # Category 5: Validation
+        print_header("CATEGORY 5: VALIDATION & ERROR HANDLING")
+        test_invalid_url()
+        test_non_existent_domain()
+        test_valid_domain()
+
+        # Category 6: Edge cases
+        print_header("CATEGORY 6: EDGE CASES")
+        test_unrelated_query()
+        test_mixed_valid_invalid()
+        test_empty_input()
+        test_long_business_name()
+        test_special_characters()
+
+        # Category 7: Session management
+        print_header("CATEGORY 7: SESSION MANAGEMENT")
+        test_invalid_session()
+        test_session_persistence()
+
+        # Category 8: End-to-end
+        print_header("CATEGORY 8: END-TO-END FLOWS")
+        test_e2e_step_by_step()
+        test_e2e_all_at_once()
+
+    except KeyboardInterrupt:
+        print(f"\n{Fore.YELLOW}Tests interrupted by user{Style.RESET_ALL}")
+    except Exception as e:
+        print(f"\n{Fore.RED}Fatal error: {e}{Style.RESET_ALL}")
+        import traceback
+        traceback.print_exc()
+
+    # Print summary
+    print_header("TEST SUMMARY")
+
+    total = stats.total
+    passed = stats.passed
+    failed = stats.failed
+    pass_rate = (passed / total * 100) if total > 0 else 0
+
+    print(f"\n{Fore.WHITE}Total Assertions: {total}{Style.RESET_ALL}")
+    print(f"{Fore.GREEN}Passed: {passed} ({pass_rate:.1f}%){Style.RESET_ALL}")
+    print(f"{Fore.RED}Failed: {failed} ({100-pass_rate:.1f}%){Style.RESET_ALL}")
+
+    if stats.failed_tests:
+        print(f"\n{Fore.RED}Failed Tests:{Style.RESET_ALL}")
+        for test in set(stats.failed_tests):
+            print(f"  {Fore.RED}x {test}{Style.RESET_ALL}")
+
+    print(f"\n{Fore.WHITE}End time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}{Style.RESET_ALL}")
+
+    if failed == 0:
+        print(f"\n{Fore.GREEN}{'='*80}")
+        print(f"{Fore.GREEN}ALL TESTS PASSED!{Style.RESET_ALL}")
+        print(f"{Fore.GREEN}{'='*80}{Style.RESET_ALL}\n")
+        return 0
+    else:
+        print(f"\n{Fore.RED}{'='*80}")
+        print(f"{Fore.RED}SOME TESTS FAILED!{Style.RESET_ALL}")
+        print(f"{Fore.RED}{'='*80}{Style.RESET_ALL}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+    exit_code = run_all_tests()
+    sys.exit(exit_code)

--- a/tests/chatv2/test_collect_data.py
+++ b/tests/chatv2/test_collect_data.py
@@ -1,0 +1,176 @@
+"""Tests for chatv2 collect_data node."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from langchain_core.messages import HumanMessage, AIMessage
+
+from agents.chatv2.nodes.collect_data import collect_data_node
+from core.chatv2.models import ChatStatus
+
+
+@pytest.fixture(autouse=True)
+def mock_langgraph_runtime():
+    """Mock LangGraph runtime helpers since tests run outside the graph."""
+    with (
+        patch("agents.chatv2.nodes.collect_data.get_stream_writer") as mock_gsw,
+        patch("agents.chatv2.nodes.collect_data.get_config") as mock_cfg,
+        patch("agents.chatv2.nodes.collect_data._get_scrape_context", return_value=None),
+    ):
+        mock_gsw.return_value = MagicMock()
+        mock_cfg.return_value = {"configurable": {"thread_id": "test-session"}}
+        yield mock_gsw.return_value
+
+
+@pytest.fixture
+def base_state():
+    """Base state for collect_data tests."""
+    return {
+        "messages": [],
+        "ad_plan": {},
+        "status": ChatStatus.IN_PROGRESS,
+        "response_message": "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_data_responds_when_user_provides_different_field(base_state):
+    """
+    When AI asks for business name but user provides budget,
+    the system should acknowledge the budget and ask for remaining fields.
+    """
+    base_state["messages"] = [
+        AIMessage(content="What's your business name?"),
+        HumanMessage(content="my budget is 5k"),
+    ]
+
+    mock_adapter = AsyncMock()
+    # First call: LLM extracts budget via tool call, empty reply
+    mock_adapter.chat_with_tools.return_value = (
+        "",  # Empty reply (LLM didn't include text with tool call)
+        [{"name": "update_ad_plan", "args": {"budget": "5000"}, "id": "call_123"}],
+        MagicMock(tool_calls=[{"name": "update_ad_plan", "args": {"budget": "5000"}, "id": "call_123"}]),
+    )
+    # Second call: continuation response
+    mock_adapter.chat.return_value = (
+        "Got it! I've noted your budget of $5,000. Could you please tell me your business name?",
+        None,
+    )
+
+    with patch("agents.chatv2.nodes.collect_data.get_llm_adapter", return_value=mock_adapter):
+        result = await collect_data_node(base_state)
+
+    assert result["response_message"] != "", "Response should not be empty when user provides valid data"
+    assert "ad_plan" in result
+    assert result["ad_plan"].get("budget") == "5000"
+    # Verify continuation was called since initial reply was empty
+    assert mock_adapter.chat.called, "Should call chat() to get continuation response"
+
+
+@pytest.mark.asyncio
+async def test_collect_data_uses_llm_reply_when_provided(base_state):
+    """When LLM provides reply with tool call, use that reply directly."""
+    base_state["messages"] = [
+        HumanMessage(content="I want to create a campaign for my bakery"),
+    ]
+
+    mock_adapter = AsyncMock()
+    mock_adapter.chat_with_tools.return_value = (
+        "Great! I've noted your business is a bakery. What's your website URL?",
+        [{"name": "update_ad_plan", "args": {"productName": "bakery"}, "id": "call_123"}],
+        MagicMock(tool_calls=[]),
+    )
+
+    with patch("agents.chatv2.nodes.collect_data.get_llm_adapter", return_value=mock_adapter):
+        result = await collect_data_node(base_state)
+
+    assert "bakery" in result["response_message"].lower() or "website" in result["response_message"].lower()
+    assert result["ad_plan"].get("productName") == "bakery"
+    # Should NOT call chat() since we already have a reply
+    assert not mock_adapter.chat.called
+
+
+@pytest.mark.asyncio
+async def test_collect_data_handles_validation_errors(base_state):
+    """When validation fails, get followup response about the error."""
+    base_state["messages"] = [
+        HumanMessage(content="budget is -500"),
+    ]
+
+    mock_adapter = AsyncMock()
+    mock_adapter.chat_with_tools.return_value = (
+        "",
+        [{"name": "update_ad_plan", "args": {"budget": "-500"}, "id": "call_123"}],
+        MagicMock(tool_calls=[{"name": "update_ad_plan", "args": {"budget": "-500"}, "id": "call_123"}]),
+    )
+    mock_adapter.chat.return_value = (
+        "Budget must be a positive number. Please provide a valid budget.",
+        None,
+    )
+
+    with patch("agents.chatv2.nodes.collect_data.get_llm_adapter", return_value=mock_adapter):
+        with patch("agents.chatv2.nodes.collect_data.validate_fields") as mock_validate:
+            mock_validate.return_value = ({}, {"budget": "must be positive"})
+            result = await collect_data_node(base_state)
+
+    assert result["response_message"] != ""
+    assert "budget" not in result["ad_plan"]
+
+
+def _all_fields_tool_call(platform: str = "google"):
+    """Helper: mock LLM returning tool call with all 5 required fields."""
+    args = {
+        "productName": "Test Biz",
+        "websiteURL": "https://test.com",
+        "budget": "5000",
+        "durationDays": "14",
+        "platform": platform,
+    }
+    return (
+        "Great, I have all the details!",
+        [{"name": "update_ad_plan", "args": args, "id": "call_all"}],
+        MagicMock(tool_calls=[]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_data_meta_platform_routes_to_meta_business(base_state):
+    """When platform=meta and all fields collected -> SELECTING_META_BUSINESS."""
+    base_state["messages"] = [
+        HumanMessage(content="Meta campaign for Test Biz, test.com, 5k, 14 days"),
+    ]
+
+    mock_adapter = AsyncMock()
+    mock_adapter.chat_with_tools.return_value = _all_fields_tool_call("meta")
+
+    with patch("agents.chatv2.nodes.collect_data.get_llm_adapter", return_value=mock_adapter):
+        with patch("agents.chatv2.nodes.collect_data.validate_fields") as mock_validate:
+            mock_validate.return_value = (
+                {"productName": "Test Biz", "websiteURL": "https://test.com", "budget": "5000", "durationDays": 14, "platform": "meta"},
+                {},
+            )
+            result = await collect_data_node(base_state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert result["ad_plan"]["platform"] == "meta"
+
+
+@pytest.mark.asyncio
+async def test_collect_data_google_platform_routes_to_mcc(base_state):
+    """When platform=google and all fields collected -> SELECTING_MCC."""
+    base_state["messages"] = [
+        HumanMessage(content="Google campaign for Test Biz, test.com, 5k, 14 days"),
+    ]
+
+    mock_adapter = AsyncMock()
+    mock_adapter.chat_with_tools.return_value = _all_fields_tool_call("google")
+
+    with patch("agents.chatv2.nodes.collect_data.get_llm_adapter", return_value=mock_adapter):
+        with patch("agents.chatv2.nodes.collect_data.validate_fields") as mock_validate:
+            mock_validate.return_value = (
+                {"productName": "Test Biz", "websiteURL": "https://test.com", "budget": "5000", "durationDays": 14, "platform": "google"},
+                {},
+            )
+            result = await collect_data_node(base_state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert result["ad_plan"]["platform"] == "google"

--- a/tests/chatv2/test_confirm.py
+++ b/tests/chatv2/test_confirm.py
@@ -1,0 +1,317 @@
+"""Tests for confirm node — campaign confirmation flow."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from agents.chatv2.nodes.confirm import confirm_node, build_summary, show_summary_node
+from core.chatv2.models import ChatStatus, AccountType
+
+
+@pytest.fixture(autouse=True)
+def mock_stream_writer():
+    """Mock get_stream_writer since tests run outside LangGraph runtime."""
+    with patch("agents.chatv2.nodes.confirm.get_stream_writer") as mock_gsw:
+        mock_gsw.return_value = MagicMock()
+        yield mock_gsw.return_value
+
+
+COMPLETE_AD_PLAN = {
+    "businessName": "Valmark Cityville",
+    "websiteURL": "https://cityville.in",
+    "budget": "12000",
+    "durationDays": 50,
+    "platform": "google",
+    "loginCustomerId": "4461972633",
+    "customerId": "4220436668",
+}
+
+SAMPLE_MCC_ACCOUNTS = [
+    {"id": "4461972633", "name": "Modlix"},
+]
+
+SAMPLE_CUSTOMER_ACCOUNTS = [
+    {"id": "4220436668", "name": "Fincity Common Ads"},
+    {"id": "4220436669", "name": "Other Account"},
+]
+
+
+@pytest.fixture
+def confirmed_state():
+    """State at confirmation stage with all fields and accounts selected."""
+    return {
+        "messages": [],
+        "ad_plan": dict(COMPLETE_AD_PLAN),
+        "status": ChatStatus.AWAITING_CONFIRMATION,
+        "response_message": "",
+        "parent_account_options": SAMPLE_MCC_ACCOUNTS,
+        "account_options": SAMPLE_CUSTOMER_ACCOUNTS,
+    }
+
+
+def _mock_tool_call(name, args=None):
+    return {"name": name, "args": args or {}, "id": "call_123"}
+
+
+def _mock_llm(tool_name=None, tool_args=None, ai_content=""):
+    """Create a mock LLM adapter returning the given tool call."""
+    adapter = AsyncMock()
+    tool_calls = [_mock_tool_call(tool_name, tool_args)] if tool_name else []
+    adapter.chat_with_tools.return_value = (ai_content, tool_calls, MagicMock())
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_wrong_account_directly_shows_account_list(confirmed_state):
+    """'wrong customer account' should immediately show account options.
+
+    Must NOT ask 'What would you like to change?' — user already specified what's wrong.
+    Regression: 'wrong' matched rejection before account change detection.
+    """
+    summary = build_summary(COMPLETE_AD_PLAN, confirmed_state)
+    confirmed_state["messages"] = [
+        AIMessage(content=summary),
+        HumanMessage(content="wrong customer account"),
+    ]
+
+    mock_adapter = _mock_llm("handle_account_selection", {"action": "account"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert result["account_selection"]["type"] == AccountType.ACCOUNT
+    assert len(result["account_selection"]["options"]) == len(SAMPLE_CUSTOMER_ACCOUNTS)
+    assert "customerId" not in result["ad_plan"]
+    assert "customer" in result["response_message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_wrong_account_typo_also_works(confirmed_state):
+    """Typos like 'wrong customer caccout' should still trigger account change."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="wrong customer caccout"),
+    ]
+
+    mock_adapter = _mock_llm("handle_account_selection", {"action": "account"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert "customerId" not in result["ad_plan"]
+
+
+@pytest.mark.asyncio
+async def test_yes_after_raised_issue_does_not_confirm(confirmed_state):
+    """'yes' after user raised an account issue should NOT finalize the campaign.
+
+    Regression: 'yes' was matched as confirmation regardless of prior context.
+    """
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="wrong customer account"),
+        AIMessage(content="What would you like to change?"),
+        HumanMessage(content="yes change the customer account"),
+    ]
+
+    mock_adapter = _mock_llm("handle_account_selection", {"action": "account"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert result["status"] != ChatStatus.COMPLETED
+    assert "customerId" not in result["ad_plan"]
+
+
+@pytest.mark.asyncio
+async def test_give_me_options_triggers_account_change(confirmed_state):
+    """'give me options' should show account options, NOT trigger scope restriction.
+
+    Regression: treated as unrelated request, got 'I can only help with advertising campaigns.'
+    """
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="wrong customer account"),
+        AIMessage(content="What would you like to change?"),
+        HumanMessage(content="give me options"),
+    ]
+
+    mock_adapter = _mock_llm("handle_account_selection", {"action": "account"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert result["account_selection"]["type"] == AccountType.ACCOUNT
+    assert len(result["account_selection"]["options"]) == len(SAMPLE_CUSTOMER_ACCOUNTS)
+    assert "customerId" not in result["ad_plan"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_campaign_sets_completed(confirmed_state):
+    """Pure confirmation -> COMPLETED status with finalized ad_plan."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="looks good"),
+    ]
+
+    mock_adapter = _mock_llm("confirm_campaign_creation")
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.COMPLETED
+    assert result["ad_plan"]["budget"] == 12000
+    assert "startDate" in result["ad_plan"]
+    assert "endDate" in result["ad_plan"]
+
+
+@pytest.mark.asyncio
+async def test_change_parent_account_resets_both_accounts(confirmed_state):
+    """Changing parent account should clear both parent and child IDs."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="change manager account"),
+    ]
+
+    mock_adapter = _mock_llm("handle_account_selection", {"action": "parent_account"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert result["account_selection"]["type"] == AccountType.PARENT_ACCOUNT
+    assert "loginCustomerId" not in result["ad_plan"]
+    assert "customerId" not in result["ad_plan"]
+
+
+@pytest.mark.asyncio
+async def test_no_tool_call_returns_ai_message(confirmed_state):
+    """No tool call from LLM -> return AI's clarification text."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="hmm"),
+    ]
+
+    mock_adapter = _mock_llm(ai_content="What would you like to change?")
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["response_message"] == "What would you like to change?"
+    assert "status" not in result
+
+
+@pytest.mark.asyncio
+async def test_no_tool_call_no_content_falls_back(confirmed_state):
+    """No tool call and empty AI content -> fallback message."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="..."),
+    ]
+
+    mock_adapter = _mock_llm(ai_content="")
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        result = await confirm_node(confirmed_state)
+
+    assert result["response_message"] == "What would you like to change?"
+
+
+@pytest.mark.asyncio
+async def test_field_modification_updates_ad_plan(confirmed_state):
+    """update_ad_plan tool call should update the field and rebuild summary."""
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="change budget to 20000"),
+    ]
+
+    mock_adapter = _mock_llm("update_ad_plan", {"budget": "20000"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        with patch("agents.chatv2.nodes.confirm.validate_fields") as mock_validate:
+            mock_validate.return_value = ({"budget": "20000"}, {})
+            result = await confirm_node(confirmed_state)
+
+    assert result["ad_plan"]["budget"] == "20000"
+    assert "20,000" in result["response_message"]
+
+
+@pytest.mark.asyncio
+async def test_platform_change_clears_old_account_fields(confirmed_state):
+    """Changing platform from google to meta should clear Google account IDs
+    and restart account selection for the new platform.
+
+    Regression: platform changed but loginCustomerId/customerId stayed in ad_plan.
+    """
+    confirmed_state["messages"] = [
+        AIMessage(content="I have the following details..."),
+        HumanMessage(content="yes I want to create add on meta"),
+    ]
+
+    mock_adapter = _mock_llm("update_ad_plan", {"platform": "meta"})
+
+    with patch("agents.chatv2.nodes.confirm.get_llm_adapter", return_value=mock_adapter):
+        with patch("agents.chatv2.nodes.confirm.validate_fields") as mock_validate:
+            mock_validate.return_value = ({"platform": "meta"}, {})
+            result = await confirm_node(confirmed_state)
+
+    assert result["ad_plan"]["platform"] == "meta"
+    assert "loginCustomerId" not in result["ad_plan"]
+    assert "customerId" not in result["ad_plan"]
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert result["parent_account_options"] == []
+    assert result["account_options"] == []
+
+
+def test_build_summary_google():
+    """Summary should format all fields with labels."""
+    state = {
+        "parent_account_options": SAMPLE_MCC_ACCOUNTS,
+        "account_options": SAMPLE_CUSTOMER_ACCOUNTS,
+    }
+    summary = build_summary(COMPLETE_AD_PLAN, state)
+
+    assert "Google Ads" in summary
+    assert "Valmark Cityville" in summary
+    assert "12,000" in summary
+    assert "50 days" in summary
+    assert "Modlix" in summary
+    assert "Fincity Common Ads" in summary
+    assert "Please confirm" in summary
+
+
+def test_build_summary_meta():
+    """Summary for Meta platform should use Meta-specific labels."""
+    ad_plan = {
+        "businessName": "Test Biz",
+        "websiteURL": "https://test.com",
+        "budget": "5000",
+        "durationDays": 14,
+        "platform": "meta",
+        "metaBusinessId": "biz_1",
+        "metaAdAccountId": "act_1",
+    }
+    state = {
+        "parent_account_options": [{"id": "biz_1", "name": "My Business"}],
+        "account_options": [{"id": "act_1", "name": "Ad Account One"}],
+    }
+    summary = build_summary(ad_plan, state)
+
+    assert "Meta Ads" in summary
+    assert "My Business" in summary
+    assert "Ad Account One" in summary
+
+
+@pytest.mark.asyncio
+async def test_show_summary_node_returns_formatted_summary(confirmed_state):
+    """show_summary_node should return the built summary."""
+    result = await show_summary_node(confirmed_state)
+
+    assert "Valmark Cityville" in result["response_message"]
+    assert "12,000" in result["response_message"]
+    assert len(result["messages"]) == 1

--- a/tests/chatv2/test_e2e_flow.py
+++ b/tests/chatv2/test_e2e_flow.py
@@ -1,0 +1,298 @@
+"""
+E2E tests for chatv2 campaign creation flow.
+
+Tests the full graph via ChatV2Agent.process_message_stream():
+  Google: collect_data → fetch_parent_account → select_parent_account → fetch_account → select_account → confirm
+  Meta:   collect_data → fetch_parent_account → select_parent_account → fetch_account → select_account → confirm
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agents.chatv2.chat_agent import ChatV2Agent
+from core.chatv2.models import ChatStatus
+from core.infrastructure.context import set_auth_context
+from exceptions.custom_exceptions import SessionException
+
+COLLECT_LLM = "agents.chatv2.nodes.collect_data.get_llm_adapter"
+COLLECT_VALIDATE = "agents.chatv2.nodes.collect_data.validate_fields"
+CONFIRM_LLM = "agents.chatv2.nodes.confirm.get_llm_adapter"
+FETCH_PARENTS = "agents.chatv2.dependencies.fetch_mcc_accounts"
+FETCH_CHILDREN = "agents.chatv2.dependencies.fetch_customer_accounts"
+FETCH_META_PARENTS = "agents.chatv2.dependencies.fetch_meta_business_accounts"
+FETCH_META_CHILDREN = "agents.chatv2.dependencies.fetch_meta_ad_accounts"
+
+GOOGLE_FIELDS = {
+    "platform": "google", "businessName": "TestCorp",
+    "websiteURL": "https://testcorp.com", "budget": "10000", "durationDays": 14,
+}
+META_FIELDS = {
+    "platform": "meta", "businessName": "TestCorp",
+    "websiteURL": "https://testcorp.com", "budget": "10000", "durationDays": 14,
+}
+
+TWO_MCCS = [{"id": "mcc_1", "name": "MCC One"}, {"id": "mcc_2", "name": "MCC Two"}]
+TWO_CUSTOMERS = [{"id": "cust_1", "name": "Customer One"}, {"id": "cust_2", "name": "Customer Two"}]
+TWO_META_BIZ = [{"id": "biz_1", "name": "Biz One"}, {"id": "biz_2", "name": "Biz Two"}]
+TWO_META_AD = [{"id": "act_1", "name": "Ad Acct One"}, {"id": "act_2", "name": "Ad Acct Two"}]
+
+ONE_MCC = [{"id": "mcc_1", "name": "Only MCC"}]
+ONE_CUSTOMER = [{"id": "cust_1", "name": "Only Customer"}]
+ONE_META_BIZ = [{"id": "biz_1", "name": "Only Biz"}]
+ONE_META_AD = [{"id": "act_1", "name": "Only Ad Acct"}]
+
+CLIENT = "TEST01"
+
+
+@pytest.fixture(autouse=True)
+def _set_auth_context():
+    """Set auth context so agent reads client_code from it."""
+    set_auth_context(client_code=CLIENT)
+
+
+async def send(agent: ChatV2Agent, session_id: str, message: str) -> SimpleNamespace:
+    """Consume stream and return the done event's data as an attribute-accessible object."""
+    events = [e async for e in agent.process_message_stream(session_id, message)]
+    done = next((e for e in events if e.event == "done"), None)
+    assert done is not None, f"No done event in stream. Events: {[e.event for e in events]}"
+    return SimpleNamespace(**done.data)
+
+
+def _llm_that_extracts(fields: dict):
+    """Mock LLM adapter: returns a tool call that extracts all given fields."""
+    adapter = AsyncMock()
+    adapter.chat_with_tools.return_value = (
+        "",  # no text reply (tool-only)
+        [{"name": "update_ad_plan", "args": {**fields, "reasoning": "all fields"}, "id": "tc1"}],
+        MagicMock(tool_calls=[{"name": "update_ad_plan", "args": fields, "id": "tc1"}]),
+    )
+    adapter.chat.return_value = ("Fields noted.", None)
+    return adapter
+
+
+def _llm_that_confirms():
+    """Mock LLM adapter: calls confirm_campaign_creation tool."""
+    adapter = AsyncMock()
+    adapter.chat_with_tools.return_value = (
+        "", [{"name": "confirm_campaign_creation", "args": {}, "id": "tc2"}], MagicMock(tool_calls=[]),
+    )
+    return adapter
+
+
+@pytest.fixture(autouse=True)
+def _mock_stream_writers():
+    """Nodes use get_stream_writer() — mock it since tests run outside LangGraph."""
+    with patch("agents.chatv2.nodes.collect_data.get_stream_writer") as m1, \
+         patch("agents.chatv2.nodes.confirm.get_stream_writer") as m2, \
+         patch("agents.chatv2.nodes.select_account.get_stream_writer") as m3:
+        writer = MagicMock()
+        m1.return_value = writer
+        m2.return_value = writer
+        m3.return_value = writer
+        yield
+
+
+@pytest.fixture
+def agent():
+    return ChatV2Agent()
+
+
+@pytest.mark.asyncio
+async def test_google_full_flow(agent):
+    """
+    Google path with multiple accounts at each step.
+    Flow: collect → fetch_parent(2) → user picks → fetch_account(2) → user picks → confirm → done
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    # --- Step 1: collect all 5 fields → shows parent account list ---
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(GOOGLE_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(GOOGLE_FIELDS, {})), \
+         patch(FETCH_PARENTS, new_callable=AsyncMock, return_value=TWO_MCCS):
+
+        r = await send(agent, sid, "Google, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "selecting_parent_account"
+    assert r.account_selection is not None
+    assert r.account_selection["type"] == "parent_account"
+    assert len(r.account_selection["options"]) == 2
+
+    # --- Step 2: pick MCC → shows customer list ---
+    with patch(FETCH_CHILDREN, new_callable=AsyncMock, return_value=TWO_CUSTOMERS):
+        r = await send(agent, sid, "mcc_1")
+
+    assert r.status == "selecting_account"
+    assert r.account_selection["type"] == "account"
+    assert len(r.account_selection["options"]) == 2
+
+    # --- Step 3: pick customer → confirmation summary ---
+    r = await send(agent, sid, "cust_1")
+
+    assert r.status == "awaiting_confirmation"
+    assert "TestCorp" in r.reply
+    assert "10,000" in r.reply
+
+    # --- Step 4: confirm → completed ---
+    with patch(CONFIRM_LLM, return_value=_llm_that_confirms()):
+        r = await send(agent, sid, "yes")
+
+    assert r.status == "completed"
+    assert r.collected_data["loginCustomerId"] == "mcc_1"
+    assert r.collected_data["customerId"] == "cust_1"
+
+
+@pytest.mark.asyncio
+async def test_google_auto_select_single_accounts(agent):
+    """
+    Single MCC + single customer → both auto-selected → straight to confirmation.
+    Flow: collect → fetch_parent(1) → auto → fetch_account(1) → auto → confirm summary
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(GOOGLE_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(GOOGLE_FIELDS, {})), \
+         patch(FETCH_PARENTS, new_callable=AsyncMock, return_value=ONE_MCC), \
+         patch(FETCH_CHILDREN, new_callable=AsyncMock, return_value=ONE_CUSTOMER):
+
+        r = await send(agent, sid, "Google, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "awaiting_confirmation"
+    assert "TestCorp" in r.reply
+
+
+@pytest.mark.asyncio
+async def test_google_no_mcc_accounts(agent):
+    """
+    No MCC accounts → stops with error, does NOT proceed to confirm.
+    Flow: collect → fetch_parent([]) → END
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(GOOGLE_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(GOOGLE_FIELDS, {})), \
+         patch(FETCH_PARENTS, new_callable=AsyncMock, return_value=[]):
+
+        r = await send(agent, sid, "Google, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "in_progress", "Should NOT route to confirm when no accounts found"
+    assert "couldn't find" in r.reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_meta_full_flow(agent):
+    """
+    Meta path with multiple accounts at each step.
+    Flow: collect → fetch_parent(2) → user picks → fetch_account(2) → user picks → confirm → done
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    # --- Step 1: collect all 5 fields → shows business list ---
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(META_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(META_FIELDS, {})), \
+         patch(FETCH_META_PARENTS, new_callable=AsyncMock, return_value=TWO_META_BIZ):
+
+        r = await send(agent, sid, "Meta, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "selecting_parent_account"
+    assert r.account_selection["type"] == "parent_account"
+    assert len(r.account_selection["options"]) == 2
+
+    # --- Step 2: pick business → shows ad account list ---
+    with patch(FETCH_META_CHILDREN, new_callable=AsyncMock, return_value=TWO_META_AD):
+        r = await send(agent, sid, "biz_1")
+
+    assert r.status == "selecting_account"
+    assert r.account_selection["type"] == "account"
+    assert len(r.account_selection["options"]) == 2
+
+    # --- Step 3: pick ad account → confirmation summary ---
+    r = await send(agent, sid, "act_1")
+
+    assert r.status == "awaiting_confirmation"
+    assert "TestCorp" in r.reply
+    assert "Meta" in r.reply
+
+    # --- Step 4: confirm → completed ---
+    with patch(CONFIRM_LLM, return_value=_llm_that_confirms()):
+        r = await send(agent, sid, "yes")
+
+    assert r.status == "completed"
+    assert r.collected_data["metaBusinessId"] == "biz_1"
+    assert r.collected_data["metaAdAccountId"] == "act_1"
+    assert r.collected_data["platform"] == "meta"
+
+
+@pytest.mark.asyncio
+async def test_meta_auto_select_single_accounts(agent):
+    """
+    Single business + single ad account → both auto-selected → straight to confirmation.
+    Flow: collect → fetch_parent(1) → auto → fetch_account(1) → auto → confirm summary
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(META_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(META_FIELDS, {})), \
+         patch(FETCH_META_PARENTS, new_callable=AsyncMock, return_value=ONE_META_BIZ), \
+         patch(FETCH_META_CHILDREN, new_callable=AsyncMock, return_value=ONE_META_AD):
+
+        r = await send(agent, sid, "Meta, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "awaiting_confirmation"
+    assert "TestCorp" in r.reply
+
+
+@pytest.mark.asyncio
+async def test_meta_no_businesses(agent):
+    """
+    No Meta businesses → stops with error, does NOT proceed to confirm.
+    Flow: collect → fetch_parent([]) → END
+    """
+    session = await agent.start_session()
+    sid = session["session_id"]
+
+    with patch(COLLECT_LLM, return_value=_llm_that_extracts(META_FIELDS)), \
+         patch(COLLECT_VALIDATE, new_callable=AsyncMock, return_value=(META_FIELDS, {})), \
+         patch(FETCH_META_PARENTS, new_callable=AsyncMock, return_value=[]):
+
+        r = await send(agent, sid, "Meta, TestCorp, testcorp.com, 10k, 14d")
+
+    assert r.status == "in_progress", "Should NOT route to confirm when no businesses found"
+    assert "couldn't find" in r.reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_start_session_greeting(agent):
+    """Start session returns greeting mentioning both platforms."""
+    result = await agent.start_session()
+    assert "session_id" in result
+    assert "Google" in result["message"]
+    assert "Meta" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_end_session(agent):
+    session = await agent.start_session()
+    result = await agent.end_session(session["session_id"])
+    assert "ended" in result["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_message_after_end_raises(agent):
+    session = await agent.start_session()
+    sid = session["session_id"]
+    await agent.end_session(sid)
+
+    with pytest.raises(SessionException, match="can not find session"):
+        agent.validate_session(sid)
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_raises(agent):
+    with pytest.raises(SessionException, match="can not find session"):
+        agent.validate_session("nonexistent")

--- a/tests/chatv2/test_select_meta_account.py
+++ b/tests/chatv2/test_select_meta_account.py
@@ -1,0 +1,293 @@
+"""Tests for account selection nodes with Meta platform config."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from agents.chatv2.nodes.select_parent_account import (
+    fetch_parent_account_options,
+    select_parent_account_node,
+)
+from agents.chatv2.nodes.select_account import (
+    fetch_account_options,
+    select_account_node,
+)
+from core.chatv2.models import ChatStatus, AccountType
+from core.infrastructure.context import set_auth_context
+
+
+@pytest.fixture(autouse=True)
+def _set_auth_context():
+    set_auth_context(client_code="TEST")
+
+
+@pytest.fixture(autouse=True)
+def mock_stream_writer():
+    """Mock get_stream_writer since tests run outside LangGraph runtime."""
+    with patch("agents.chatv2.nodes.select_parent_account.get_stream_writer") as mock_parent, \
+         patch("agents.chatv2.nodes.select_account.get_stream_writer") as mock_child:
+        writer = MagicMock()
+        mock_parent.return_value = writer
+        mock_child.return_value = writer
+        yield writer
+
+
+COMPLETE_AD_PLAN = {
+    "businessName": "Test Biz",
+    "websiteURL": "https://test.com",
+    "budget": "5000",
+    "durationDays": 14,
+    "platform": "meta",
+}
+
+SAMPLE_BUSINESSES = [
+    {"id": "biz_1", "name": "Business One"},
+    {"id": "biz_2", "name": "Business Two"},
+]
+
+SAMPLE_AD_ACCOUNTS = [
+    {"id": "act_1", "name": "Ad Account One"},
+    {"id": "act_2", "name": "Ad Account Two"},
+]
+
+
+def _make_message(content: str):
+    """Create a simple message object with .content attribute."""
+    msg = MagicMock()
+    msg.content = content
+    return msg
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_business_accounts", new_callable=AsyncMock)
+async def test_fetch_business_empty_list(mock_fetch):
+    """No businesses found -> IN_PROGRESS status, empty options."""
+    mock_fetch.return_value = []
+    state = {"ad_plan": {"platform": "meta"}}
+
+    result = await fetch_parent_account_options(state)
+
+    assert result["status"] == ChatStatus.IN_PROGRESS
+    assert result["parent_account_options"] == []
+    assert result["account_selection"] is None
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_business_accounts", new_callable=AsyncMock)
+async def test_fetch_business_single_auto_selects(mock_fetch_biz):
+    """Single business -> auto-select parent, proceed to account fetch."""
+    single_biz = [{"id": "biz_1", "name": "Only Biz"}]
+    mock_fetch_biz.return_value = single_biz
+
+    state = {"ad_plan": dict(COMPLETE_AD_PLAN)}
+
+    result = await fetch_parent_account_options(state)
+
+    assert result["ad_plan"]["metaBusinessId"] == "biz_1"
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert "Only Biz" in result["response_message"]
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_business_accounts", new_callable=AsyncMock)
+async def test_fetch_business_multiple_shows_selection(mock_fetch):
+    """Multiple businesses -> SELECTING_PARENT_ACCOUNT with account_selection."""
+    mock_fetch.return_value = SAMPLE_BUSINESSES
+    state = {"ad_plan": {"platform": "meta"}}
+
+    result = await fetch_parent_account_options(state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert len(result["parent_account_options"]) == 2
+    assert result["account_selection"]["type"] == AccountType.PARENT_ACCOUNT
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_ad_accounts", new_callable=AsyncMock)
+async def test_fetch_ad_accounts_single_auto_selects(mock_fetch):
+    """Single ad account -> auto-select, AWAITING_CONFIRMATION."""
+    mock_fetch.return_value = [{"id": "act_1", "name": "Only Account"}]
+    state = {
+        "ad_plan": {**COMPLETE_AD_PLAN, "metaBusinessId": "biz_1"},
+        "parent_account_options": SAMPLE_BUSINESSES,
+    }
+
+    result = await fetch_account_options(state)
+
+    assert result["ad_plan"]["metaAdAccountId"] == "act_1"
+    assert result["status"] == ChatStatus.AWAITING_CONFIRMATION
+    assert result["account_selection"] is None
+
+
+@pytest.mark.asyncio
+async def test_select_business_valid():
+    """Valid business selection -> sets parent ID, proceeds to account fetch."""
+    state = {
+        "messages": [_make_message("biz_1")],
+        "parent_account_options": SAMPLE_BUSINESSES,
+        "ad_plan": dict(COMPLETE_AD_PLAN),
+    }
+
+    result = await select_parent_account_node(state)
+
+    assert result["ad_plan"]["metaBusinessId"] == "biz_1"
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+
+
+@pytest.mark.asyncio
+async def test_select_business_invalid():
+    """Invalid selection -> re-show business list."""
+    state = {
+        "messages": [_make_message("invalid_id")],
+        "parent_account_options": SAMPLE_BUSINESSES,
+        "ad_plan": dict(COMPLETE_AD_PLAN),
+
+    }
+
+    result = await select_parent_account_node(state)
+
+    assert "Invalid" in result["response_message"]
+    assert result["account_selection"]["type"] == AccountType.PARENT_ACCOUNT
+
+
+@pytest.mark.asyncio
+async def test_select_business_no_messages():
+    """No messages -> prompt user to select."""
+    state = {
+        "messages": [],
+        "parent_account_options": SAMPLE_BUSINESSES,
+        "ad_plan": {"platform": "meta"},
+
+    }
+
+    result = await select_parent_account_node(state)
+
+    assert "select" in result["response_message"].lower()
+    assert result["account_selection"]["type"] == AccountType.PARENT_ACCOUNT
+
+
+@pytest.mark.asyncio
+async def test_select_business_valid_sets_name():
+    """Valid business selection -> response includes selected name."""
+    state = {
+        "messages": [_make_message("biz_1")],
+        "parent_account_options": SAMPLE_BUSINESSES,
+        "ad_plan": dict(COMPLETE_AD_PLAN),
+    }
+
+    result = await select_parent_account_node(state)
+
+    assert "Business One" in result["response_message"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_ad_accounts_no_business_id():
+    """No business_id -> prompt user to select business first."""
+    state = {
+        "ad_plan": {"platform": "meta"},
+        "parent_account_options": SAMPLE_BUSINESSES,
+
+    }
+
+    result = await fetch_account_options(state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert "business" in result["response_message"].lower()
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_ad_accounts", new_callable=AsyncMock)
+async def test_fetch_ad_accounts_has_accounts(mock_fetch):
+    """Business has ad accounts -> SELECTING_ACCOUNT."""
+    mock_fetch.return_value = SAMPLE_AD_ACCOUNTS
+    state = {
+        "ad_plan": {"platform": "meta", "metaBusinessId": "biz_1"},
+        "parent_account_options": SAMPLE_BUSINESSES,
+
+    }
+
+    result = await fetch_account_options(state)
+
+    assert result["status"] == ChatStatus.SELECTING_ACCOUNT
+    assert len(result["account_options"]) == 2
+    assert result["account_selection"]["type"] == AccountType.ACCOUNT
+
+
+@pytest.mark.asyncio
+@patch("agents.chatv2.dependencies.fetch_meta_ad_accounts", new_callable=AsyncMock)
+async def test_fetch_ad_accounts_empty(mock_fetch):
+    """No ad accounts -> fall back to SELECTING_PARENT_ACCOUNT."""
+    mock_fetch.return_value = []
+    state = {
+        "ad_plan": {"platform": "meta", "metaBusinessId": "biz_1"},
+        "parent_account_options": SAMPLE_BUSINESSES,
+
+    }
+
+    result = await fetch_account_options(state)
+
+    assert result["status"] == ChatStatus.SELECTING_PARENT_ACCOUNT
+    assert result["account_options"] == []
+
+
+@pytest.mark.asyncio
+async def test_select_ad_account_valid_all_fields():
+    """Valid selection with all fields -> AWAITING_CONFIRMATION."""
+    ad_plan = {
+        **COMPLETE_AD_PLAN,
+        "metaBusinessId": "biz_1",
+    }
+    state = {
+        "messages": [_make_message("act_1")],
+        "account_options": SAMPLE_AD_ACCOUNTS,
+        "ad_plan": ad_plan,
+    }
+
+    result = await select_account_node(state)
+
+    assert result["ad_plan"]["metaAdAccountId"] == "act_1"
+    assert result["status"] == ChatStatus.AWAITING_CONFIRMATION
+
+
+@pytest.mark.asyncio
+async def test_select_ad_account_valid_missing_fields():
+    """Valid selection but missing base fields -> IN_PROGRESS."""
+    state = {
+        "messages": [_make_message("act_1")],
+        "account_options": SAMPLE_AD_ACCOUNTS,
+        "ad_plan": {"platform": "meta", "metaBusinessId": "biz_1"},
+    }
+
+    result = await select_account_node(state)
+
+    assert result["ad_plan"]["metaAdAccountId"] == "act_1"
+    assert result["status"] == ChatStatus.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_select_ad_account_invalid():
+    """Invalid selection -> re-show ad account list."""
+    state = {
+        "messages": [_make_message("bad_id")],
+        "account_options": SAMPLE_AD_ACCOUNTS,
+        "ad_plan": dict(COMPLETE_AD_PLAN),
+    }
+
+    result = await select_account_node(state)
+
+    assert "Invalid" in result["response_message"]
+    assert result["account_selection"]["type"] == AccountType.ACCOUNT
+
+
+@pytest.mark.asyncio
+async def test_select_ad_account_no_messages():
+    """No messages -> prompt user to select."""
+    state = {
+        "messages": [],
+        "account_options": SAMPLE_AD_ACCOUNTS,
+        "ad_plan": {"platform": "meta"},
+    }
+
+    result = await select_account_node(state)
+
+    assert "select" in result["response_message"].lower()
+    assert result["account_selection"]["type"] == AccountType.ACCOUNT

--- a/tests/streaming/test_events.py
+++ b/tests/streaming/test_events.py
@@ -1,0 +1,253 @@
+"""Tests for core.streaming.events — StreamEvent model, factory functions, SSE serialization."""
+
+import json
+
+import pytest
+
+from core.streaming.events import (
+    StreamEvent,
+    content_event,
+    data_event,
+    done_event,
+    error_event,
+    status_event,
+    progress_event,
+    tool_call_event,
+)
+
+
+class TestStreamEventModel:
+
+    def test_create_with_valid_event_type(self):
+        event = StreamEvent(event="progress", data={"node": "collect_data"})
+        assert event.event == "progress"
+        assert event.data == {"node": "collect_data"}
+
+    def test_rejects_invalid_event_type(self):
+        with pytest.raises(Exception):
+            StreamEvent(event="invalid_type", data={})
+
+    @pytest.mark.parametrize("event_type", [
+        "progress", "content", "tool_call", "status", "data", "error", "done",
+    ])
+    def test_all_event_types_accepted(self, event_type):
+        event = StreamEvent(event=event_type, data={})
+        assert event.event == event_type
+
+
+class TestToSse:
+
+    def test_sse_format_has_event_line_and_data_line(self):
+        event = StreamEvent(event="progress", data={"node": "collect_data"})
+        sse = event.to_sse()
+        lines = sse.split("\n")
+        assert lines[0] == "event: progress"
+        assert lines[1].startswith("data: ")
+        assert sse.endswith("\n\n")
+
+    def test_sse_data_is_valid_json(self):
+        event = progress_event(node="confirm", message="Preparing summary...")
+        sse = event.to_sse()
+        data_line = sse.split("\n")[1]
+        payload = json.loads(data_line.removeprefix("data: "))
+        assert payload["event"] == "progress"
+        assert payload["data"]["node"] == "confirm"
+        assert payload["data"]["message"] == "Preparing summary..."
+
+    def test_sse_double_newline_terminator(self):
+        event = done_event(status="completed")
+        sse = event.to_sse()
+        assert sse.endswith("\n\n")
+        assert not sse.endswith("\n\n\n")
+
+
+class TestFactoryFunctions:
+
+    def test_progress_event(self):
+        event = progress_event(node="collect_data", message="Understanding your needs...")
+        assert event.event == "progress"
+        assert event.data["node"] == "collect_data"
+        assert event.data["message"] == "Understanding your needs..."
+        assert event.data["phase"] == "update"
+        assert event.data["label"] == ""
+
+    def test_progress_event_defaults(self):
+        event = progress_event(node="fetch_mcc")
+        assert event.data["message"] == ""
+        assert event.data["phase"] == "update"
+        assert event.data["label"] == ""
+
+    def test_progress_event_start_phase(self):
+        event = progress_event(node="collect_data", phase="start", label="Collecting campaign details")
+        assert event.data["phase"] == "start"
+        assert event.data["label"] == "Collecting campaign details"
+        assert event.data["message"] == ""
+
+    def test_content_event(self):
+        event = content_event(token="Hello", node="collect_data")
+        assert event.event == "content"
+        assert event.data["token"] == "Hello"
+        assert event.data["node"] == "collect_data"
+
+    def test_content_event_default_node(self):
+        event = content_event(token="world")
+        assert event.data["node"] == ""
+
+    def test_tool_call_event(self):
+        event = tool_call_event(
+            name="update_ad_plan",
+            args={"budget": "5000"},
+            result={"saved": {"budget": "5000"}},
+        )
+        assert event.event == "tool_call"
+        assert event.data["name"] == "update_ad_plan"
+        assert event.data["args"] == {"budget": "5000"}
+        assert event.data["result"]["saved"]["budget"] == "5000"
+
+    def test_tool_call_event_default_result(self):
+        event = tool_call_event(name="update_ad_plan", args={})
+        assert event.data["result"] is None
+
+    def test_status_event(self):
+        event = status_event(status="selecting_mcc", progress="2/3", node="fetch_mcc")
+        assert event.event == "status"
+        assert event.data["status"] == "selecting_mcc"
+        assert event.data["progress"] == "2/3"
+        assert event.data["node"] == "fetch_mcc"
+
+    def test_data_event(self):
+        event = data_event(data_type="account_options", payload={"options": [{"id": "1"}]})
+        assert event.event == "data"
+        assert event.data["type"] == "account_options"
+        assert event.data["payload"]["options"][0]["id"] == "1"
+
+    def test_error_event(self):
+        event = error_event(message="Something went wrong", code=502, recoverable=True)
+        assert event.event == "error"
+        assert event.data["message"] == "Something went wrong"
+        assert event.data["code"] == 502
+        assert event.data["recoverable"] is True
+
+    def test_error_event_defaults(self):
+        event = error_event(message="fail")
+        assert event.data["code"] == 500
+        assert event.data["recoverable"] is False
+
+    def test_done_event_with_payload(self):
+        event = done_event(status="completed", reply="Campaign created!", progress="3/3")
+        assert event.event == "done"
+        assert event.data["status"] == "completed"
+        assert event.data["reply"] == "Campaign created!"
+        assert event.data["progress"] == "3/3"
+
+    def test_done_event_empty(self):
+        event = done_event()
+        assert event.event == "done"
+        assert event.data == {}
+
+
+class TestTransientFlag:
+    """Verify transient defaults per event type."""
+
+    def test_progress_is_transient(self):
+        event = progress_event(node="scrape")
+        assert event.transient is True
+
+    def test_status_is_transient(self):
+        event = status_event(status="running", progress="1/3")
+        assert event.transient is True
+
+    def test_content_is_persistent(self):
+        event = content_event(token="Hello")
+        assert event.transient is False
+
+    def test_data_is_persistent(self):
+        event = data_event(data_type="metadata", payload={"key": "val"})
+        assert event.transient is False
+
+    def test_error_is_persistent(self):
+        event = error_event(message="fail")
+        assert event.transient is False
+
+    def test_done_is_persistent(self):
+        event = done_event(status="completed")
+        assert event.transient is False
+
+    def test_tool_call_is_persistent(self):
+        event = tool_call_event(name="fn", args={})
+        assert event.transient is False
+
+
+class TestReconciliationId:
+    """Verify reconciliation id field on StreamEvent."""
+
+    def test_default_id_is_none(self):
+        event = progress_event(node="scrape")
+        assert event.id is None
+
+    def test_progress_accepts_id(self):
+        event = progress_event(node="geo", id="geo-progress")
+        assert event.id == "geo-progress"
+
+    def test_status_accepts_id(self):
+        event = status_event(status="running", progress="1/3", id="step-1")
+        assert event.id == "step-1"
+
+    def test_data_accepts_id(self):
+        event = data_event("grid_progress", {"resolved": 10}, id="geo-progress")
+        assert event.id == "geo-progress"
+
+    def test_id_serialized_in_json(self):
+        event = data_event("grid_progress", {"resolved": 10}, id="geo-progress")
+        sse = event.to_sse()
+        payload = json.loads(sse.split("\n")[1].removeprefix("data: "))
+        assert payload["id"] == "geo-progress"
+
+    def test_id_none_serialized_as_null(self):
+        event = data_event("metadata", {"key": "val"})
+        sse = event.to_sse()
+        payload = json.loads(sse.split("\n")[1].removeprefix("data: "))
+        assert payload["id"] is None
+
+
+class TestSseRoundTrip:
+    """Verify SSE serialization produces parseable events for an EventSource client."""
+
+    def test_content_token_round_trip(self):
+        original = content_event(token="Hello world", node="collect_data")
+        sse = original.to_sse()
+
+        event_line, data_line, *_ = sse.split("\n")
+        assert event_line == "event: content"
+
+        parsed = json.loads(data_line.removeprefix("data: "))
+        restored = StreamEvent(**parsed)
+        assert restored == original
+
+    def test_error_event_round_trip(self):
+        original = error_event(message="Timeout", code=504, recoverable=True)
+        sse = original.to_sse()
+
+        parsed = json.loads(sse.split("\n")[1].removeprefix("data: "))
+        restored = StreamEvent(**parsed)
+        assert restored == original
+
+    def test_data_event_with_id_round_trip(self):
+        original = data_event("grid_progress", {"resolved": 10}, id="geo-progress")
+        sse = original.to_sse()
+
+        parsed = json.loads(sse.split("\n")[1].removeprefix("data: "))
+        restored = StreamEvent(**parsed)
+        assert restored == original
+        assert restored.id == "geo-progress"
+        assert restored.transient is False
+
+    def test_transient_progress_round_trip(self):
+        original = progress_event(node="scrape", message="Scraping...", id="scrape-1")
+        sse = original.to_sse()
+
+        parsed = json.loads(sse.split("\n")[1].removeprefix("data: "))
+        restored = StreamEvent(**parsed)
+        assert restored == original
+        assert restored.transient is True
+        assert restored.id == "scrape-1"

--- a/tests/streaming/test_langgraph_translator.py
+++ b/tests/streaming/test_langgraph_translator.py
@@ -1,0 +1,101 @@
+"""Tests for core.streaming.langgraph_translator — maps stream_mode chunks to StreamEvents."""
+
+from types import SimpleNamespace
+
+from core.streaming.langgraph_translator import translate_stream_chunk
+
+
+class TestCustomEvents:
+    """Test translate_stream_chunk("custom", ...) — events from get_stream_writer()."""
+
+    def test_progress_event_update(self):
+        data = {"type": "progress", "node": "collect_data", "content": "Interpreting 12k as budget"}
+        events = translate_stream_chunk("custom", data)
+        assert len(events) == 1
+        assert events[0].event == "progress"
+        assert events[0].data["node"] == "collect_data"
+        assert events[0].data["message"] == "Interpreting 12k as budget"
+        assert events[0].data["phase"] == "update"
+        assert events[0].data["label"] == ""
+
+    def test_progress_event_start_with_label(self):
+        data = {"type": "progress", "node": "collect_data", "phase": "start", "label": "Collecting campaign details"}
+        events = translate_stream_chunk("custom", data)
+        assert len(events) == 1
+        assert events[0].data["phase"] == "start"
+        assert events[0].data["label"] == "Collecting campaign details"
+        assert events[0].data["message"] == ""
+
+    def test_field_update_event(self):
+        data = {"type": "field_update", "field": "budget", "value": "12000", "status": "valid"}
+        events = translate_stream_chunk("custom", data)
+        assert len(events) == 1
+        assert events[0].event == "data"
+        assert events[0].data["type"] == "field_update"
+        assert events[0].data["payload"]["field"] == "budget"
+        assert events[0].data["payload"]["value"] == "12000"
+        assert events[0].data["payload"]["status"] == "valid"
+
+    def test_field_update_with_error(self):
+        data = {"type": "field_update", "field": "websiteURL", "value": "bad", "status": "invalid", "error": "Invalid URL"}
+        events = translate_stream_chunk("custom", data)
+        assert events[0].data["payload"]["error"] == "Invalid URL"
+
+    def test_status_event(self):
+        data = {"type": "status", "status": "selecting_mcc", "progress": "2/3", "node": "collect_data"}
+        events = translate_stream_chunk("custom", data)
+        assert len(events) == 1
+        assert events[0].event == "status"
+        assert events[0].data["status"] == "selecting_mcc"
+        assert events[0].data["progress"] == "2/3"
+
+    def test_tool_call_event(self):
+        data = {"type": "tool_call", "name": "update_ad_plan", "args": {"budget": "5000"}}
+        events = translate_stream_chunk("custom", data)
+        assert len(events) == 1
+        assert events[0].event == "tool_call"
+        assert events[0].data["name"] == "update_ad_plan"
+
+    def test_unknown_custom_type_ignored(self):
+        data = {"type": "something_else", "content": "whatever"}
+        events = translate_stream_chunk("custom", data)
+        assert events == []
+
+    def test_empty_custom_data_ignored(self):
+        events = translate_stream_chunk("custom", {})
+        assert events == []
+
+
+class TestMessageChunks:
+    """Test translate_stream_chunk("messages", ...) — (AIMessageChunk, metadata) tuples."""
+
+    def test_content_token_extracted(self):
+        chunk = SimpleNamespace(content="Hello")
+        metadata = {"langgraph_node": "collect_data"}
+        events = translate_stream_chunk("messages", (chunk, metadata))
+        assert len(events) == 1
+        assert events[0].event == "content"
+        assert events[0].data["token"] == "Hello"
+        assert events[0].data["node"] == "collect_data"
+
+    def test_empty_content_ignored(self):
+        chunk = SimpleNamespace(content="")
+        events = translate_stream_chunk("messages", (chunk, {}))
+        assert events == []
+
+    def test_no_content_attr_ignored(self):
+        chunk = SimpleNamespace()
+        events = translate_stream_chunk("messages", (chunk, {}))
+        assert events == []
+
+
+class TestUnknownModes:
+    """Test that unknown stream modes are gracefully ignored."""
+
+    def test_values_mode_returns_empty(self):
+        events = translate_stream_chunk("values", {"status": "in_progress"})
+        assert events == []
+
+    def test_unknown_mode_returns_empty(self):
+        events = translate_stream_chunk("debug", {"data": "something"})
+        assert events == []

--- a/tests/streaming/test_sse_endpoint.py
+++ b/tests/streaming/test_sse_endpoint.py
@@ -1,0 +1,489 @@
+"""Tests for SSE streaming: sse.py wrapper + chatv2 /stream endpoint integration."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from core.streaming.events import (
+    StreamEvent,
+    content_event,
+    done_event,
+    error_event,
+    progress_event,
+)
+from core.streaming.sse import (
+    _sse_stream,
+    _buffer_append,
+    replay_missed_events,
+    EVENT_BUFFER_MAX_SIZE,
+)
+from core.chatv2.models import ChatStatus
+
+
+class TestSseStream:
+    """Unit tests for _sse_stream — the error-safe SSE wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_yields_sse_formatted_events_with_ids(self):
+        async def mock_events():
+            yield progress_event(node="collect_data", message="Thinking...")
+            yield content_event(token="Hi there")
+
+        chunks = [chunk async for chunk in _sse_stream(mock_events())]
+
+        assert len(chunks) == 3  # 2 events + final comment
+        assert chunks[0].startswith("id: 1\nevent: progress")
+        assert chunks[1].startswith("id: 2\nevent: content")
+        assert chunks[2] == ":\n\n"
+
+    @pytest.mark.asyncio
+    async def test_catches_mid_stream_error_with_id(self):
+        async def failing_events():
+            yield progress_event(node="collect_data")
+            raise RuntimeError("LLM crashed")
+
+        chunks = [chunk async for chunk in _sse_stream(failing_events())]
+
+        assert len(chunks) == 3  # progress + error + final comment
+        assert chunks[0].startswith("id: 1\nevent: progress")
+        assert "id: 2\n" in chunks[1]
+        assert "event: error" in chunks[1]
+        # Parse error data — skip id: line and event: line
+        data_line = [l for l in chunks[1].split("\n") if l.startswith("data: ")][0]
+        error_data = json.loads(data_line.removeprefix("data: "))
+        assert "LLM crashed" in error_data["data"]["message"]
+        assert chunks[2] == ":\n\n"
+
+    @pytest.mark.asyncio
+    async def test_always_ends_with_comment_line(self):
+        async def empty_events():
+            return
+            yield  # make it an async generator
+
+        chunks = [chunk async for chunk in _sse_stream(empty_events())]
+        assert chunks == [":\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_sequential_ids_increment(self):
+        async def mock_events():
+            yield progress_event(node="a")
+            yield progress_event(node="b")
+            yield progress_event(node="c")
+
+        chunks = [chunk async for chunk in _sse_stream(mock_events())]
+
+        assert chunks[0].startswith("id: 1\n")
+        assert chunks[1].startswith("id: 2\n")
+        assert chunks[2].startswith("id: 3\n")
+
+
+class TestStreamEndpoint:
+    """Integration tests for POST /{session_id}/stream using httpx + mock graph."""
+
+    @pytest.fixture
+    def mock_session_store(self):
+        store = MagicMock()
+        store.get.return_value = {
+            "messages": [],
+            "status": ChatStatus.IN_PROGRESS,
+            "ad_plan": {},
+            "response_message": "",
+
+            "parent_account_options": [],
+            "account_options": [],
+            "account_selection": None,
+        }
+        store.exists.return_value = True
+        return store
+
+    def _make_final_state(self):
+        return {
+            "messages": [],
+            "status": ChatStatus.IN_PROGRESS,
+            "ad_plan": {},
+            "response_message": "Hello!",
+            "parent_account_options": [],
+            "account_options": [],
+            "account_selection": None,
+        }
+
+    def _make_stream_chunks(self):
+        """Simulate astream(stream_mode=["custom", "messages"]) output."""
+        return [
+            ("custom", {"type": "progress", "node": "collect_data", "content": "Analyzing message..."}),
+            ("messages", (SimpleNamespace(content="Hello!"), {"langgraph_node": "collect_data"})),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stream_endpoint_returns_sse_content_type(self, mock_session_store):
+        final_state = self._make_final_state()
+
+        async def mock_astream(state, config=None, stream_mode=None):
+            for chunk in self._make_stream_chunks():
+                yield chunk
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+        mock_graph.aget_state = AsyncMock(return_value=SimpleNamespace(values=final_state))
+
+        with (
+            patch("agents.chatv2.chat_agent.get_session_store", return_value=mock_session_store),
+            patch("agents.chatv2.chat_agent.get_chat_graph", return_value=mock_graph),
+        ):
+            from agents.chatv2.chat_agent import ChatV2Agent
+            agent = ChatV2Agent()
+            agent._graph = mock_graph
+            agent._session_store = mock_session_store
+
+            with patch("api.chatv2.chatv2_agent", agent):
+                from api.chatv2 import router
+                from fastapi import FastAPI
+                app = FastAPI()
+                app.include_router(router)
+
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    response = await client.post(
+                        "/api/ds/chatv2/test-session/stream",
+                        params={"message": "hi", "clientCode": "TEST"},
+                    )
+
+                    assert response.status_code == 200
+                    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+                    assert response.headers["cache-control"] == "no-cache"
+                    assert response.headers["x-accel-buffering"] == "no"
+
+    @pytest.mark.asyncio
+    async def test_stream_endpoint_produces_expected_event_sequence(self, mock_session_store):
+        final_state = self._make_final_state()
+
+        async def mock_astream(state, config=None, stream_mode=None):
+            for chunk in self._make_stream_chunks():
+                yield chunk
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+        mock_graph.aget_state = AsyncMock(return_value=SimpleNamespace(values=final_state))
+
+        with (
+            patch("agents.chatv2.chat_agent.get_session_store", return_value=mock_session_store),
+            patch("agents.chatv2.chat_agent.get_chat_graph", return_value=mock_graph),
+        ):
+            from agents.chatv2.chat_agent import ChatV2Agent
+            agent = ChatV2Agent()
+            agent._graph = mock_graph
+            agent._session_store = mock_session_store
+
+            with patch("api.chatv2.chatv2_agent", agent):
+                from api.chatv2 import router
+                from fastapi import FastAPI
+                app = FastAPI()
+                app.include_router(router)
+
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    response = await client.post(
+                        "/api/ds/chatv2/test-session/stream",
+                        params={"message": "hi", "clientCode": "TEST"},
+                    )
+
+                    body = response.text
+                    parsed_events = _parse_sse_body(body)
+
+                    event_types = [e["event"] for e in parsed_events]
+                    assert "progress" in event_types
+                    assert "content" in event_types
+                    assert "done" in event_types
+                    assert event_types[-1] == "done"
+
+    @pytest.mark.asyncio
+    async def test_stream_endpoint_invalid_session(self, mock_session_store):
+        mock_session_store.get.return_value = None
+
+        with (
+            patch("agents.chatv2.chat_agent.get_session_store", return_value=mock_session_store),
+            patch("agents.chatv2.chat_agent.get_chat_graph", return_value=MagicMock()),
+        ):
+            from agents.chatv2.chat_agent import ChatV2Agent
+            agent = ChatV2Agent()
+            agent._session_store = mock_session_store
+
+            with patch("api.chatv2.chatv2_agent", agent):
+                from api.chatv2 import router
+                from fastapi import FastAPI
+                from exceptions.handlers import setup_exception_handlers
+                app = FastAPI()
+                app.include_router(router)
+                setup_exception_handlers(app)
+
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    response = await client.post(
+                        "/api/ds/chatv2/invalid-session/stream",
+                        params={"message": "hi", "clientCode": "TEST"},
+                    )
+
+                    assert response.status_code == 401
+                    body = response.json()
+                    assert "session" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_stream_endpoint_completed_session(self, mock_session_store):
+        state = mock_session_store.get.return_value
+        state["status"] = ChatStatus.COMPLETED
+
+        with (
+            patch("agents.chatv2.chat_agent.get_session_store", return_value=mock_session_store),
+            patch("agents.chatv2.chat_agent.get_chat_graph", return_value=MagicMock()),
+        ):
+            from agents.chatv2.chat_agent import ChatV2Agent
+            agent = ChatV2Agent()
+            agent._session_store = mock_session_store
+
+            with patch("api.chatv2.chatv2_agent", agent):
+                from api.chatv2 import router
+                from fastapi import FastAPI
+                from exceptions.handlers import setup_exception_handlers
+                app = FastAPI()
+                app.include_router(router)
+                setup_exception_handlers(app)
+
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    response = await client.post(
+                        "/api/ds/chatv2/test-session/stream",
+                        params={"message": "hi", "clientCode": "TEST"},
+                    )
+
+                    assert response.status_code == 401
+                    assert "completed" in response.json()["error"].lower()
+
+
+class TestProcessMessageStream:
+    """Unit tests for ChatV2Agent.process_message_stream async generator."""
+
+    def _make_final_state(self):
+        return {
+            "messages": [],
+            "status": ChatStatus.IN_PROGRESS,
+            "ad_plan": {},
+            "response_message": "Hi",
+            "parent_account_options": [],
+            "account_options": [],
+            "account_selection": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_yields_translated_events_and_done(self):
+        final_state = self._make_final_state()
+
+        async def mock_astream(state, config=None, stream_mode=None):
+            yield ("custom", {"type": "progress", "node": "collect_data", "content": "Analyzing..."})
+            yield ("messages", (SimpleNamespace(content="Hi"), {"langgraph_node": "collect_data"}))
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+        mock_graph.aget_state = AsyncMock(return_value=SimpleNamespace(values=final_state))
+
+        mock_store = MagicMock()
+        mock_store.get.return_value = {
+            "messages": [],
+            "status": ChatStatus.IN_PROGRESS,
+            "ad_plan": {},
+            "response_message": "",
+        }
+
+        from agents.chatv2.chat_agent import ChatV2Agent
+        agent = ChatV2Agent()
+        agent._graph = mock_graph
+        agent._session_store = mock_store
+
+        events = []
+        async for event in agent.process_message_stream("test-session", "hi"):
+            events.append(event)
+
+        event_types = [e.event for e in events]
+        assert "progress" in event_types
+        assert "content" in event_types
+        assert event_types[-1] == "done"
+
+        mock_store.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_graph_exception_caught_by_sse_stream(self):
+        """Mid-stream exceptions bubble up from process_message_stream,
+        caught by _sse_stream safety net (the real error boundary)."""
+        async def failing_astream(state, config=None, stream_mode=None):
+            yield ("custom", {"type": "progress", "node": "collect_data", "content": "Starting..."})
+            raise RuntimeError("Graph exploded")
+
+        mock_graph = MagicMock()
+        mock_graph.astream = failing_astream
+
+        mock_store = MagicMock()
+        mock_store.get.return_value = {
+            "messages": [],
+            "status": ChatStatus.IN_PROGRESS,
+            "ad_plan": {},
+            "response_message": "",
+        }
+
+        from agents.chatv2.chat_agent import ChatV2Agent
+        agent = ChatV2Agent()
+        agent._graph = mock_graph
+        agent._session_store = mock_store
+
+        chunks = [chunk async for chunk in _sse_stream(
+            agent.process_message_stream("s1", "hi")
+        )]
+
+        assert any("event: error" in c for c in chunks)
+        error_chunk = next(c for c in chunks if "event: error" in c)
+        data_line = [l for l in error_chunk.split("\n") if l.startswith("data: ")][0]
+        error_data = json.loads(data_line.removeprefix("data: "))
+        assert "Graph exploded" in error_data["data"]["message"]
+
+
+class TestSseHeartbeat:
+    """Tests for SSE heartbeat on inactivity."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_emitted_on_inactivity(self):
+        """When the source generator stalls, heartbeat comments are emitted."""
+        heartbeat_sent = asyncio.Event()
+
+        async def slow_events():
+            yield progress_event(node="a")
+            # Stall long enough for a heartbeat
+            await heartbeat_sent.wait()
+            yield content_event(token="done")
+
+        chunks: list[str] = []
+        async for chunk in _sse_stream(slow_events()):
+            chunks.append(chunk)
+            if chunk == ": heartbeat\n\n":
+                heartbeat_sent.set()
+            if len(chunks) > 5:
+                heartbeat_sent.set()
+                break
+
+        assert ": heartbeat\n\n" in chunks
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_is_valid_sse_comment(self):
+        """Heartbeat must be a valid SSE comment (colon-prefixed)."""
+        async def stalling_events():
+            await asyncio.sleep(20)
+            return
+            yield  # make it an async generator
+
+        chunks = []
+        async for chunk in _sse_stream(stalling_events()):
+            chunks.append(chunk)
+            if chunk.startswith(":") and "heartbeat" in chunk:
+                break
+
+        heartbeat = chunks[-1]
+        assert heartbeat.startswith(":")
+        assert heartbeat.endswith("\n\n")
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_events_flow_fast(self):
+        """If events arrive faster than 15s, no heartbeat should appear."""
+        async def fast_events():
+            for i in range(5):
+                yield progress_event(node=f"step_{i}")
+
+        chunks = [chunk async for chunk in _sse_stream(fast_events())]
+        assert ": heartbeat\n\n" not in chunks
+
+
+class TestLastEventIdReplay:
+    """Tests for Last-Event-ID skip and replay buffer."""
+
+    @pytest.mark.asyncio
+    async def test_events_after_last_event_id_are_yielded(self):
+        """With last_event_id=2, events 1-2 are skipped, 3+ yielded."""
+        async def mock_events():
+            yield progress_event(node="a")
+            yield progress_event(node="b")
+            yield content_event(token="c")
+
+        chunks = [chunk async for chunk in _sse_stream(mock_events(), last_event_id=2)]
+        # Only event 3 + final comment
+        event_chunks = [c for c in chunks if c != ":\n\n"]
+        assert len(event_chunks) == 1
+        assert event_chunks[0].startswith("id: 3\n")
+
+    @pytest.mark.asyncio
+    async def test_last_event_id_zero_yields_all(self):
+        """last_event_id=0 (default) yields every event."""
+        async def mock_events():
+            yield progress_event(node="a")
+            yield content_event(token="b")
+
+        chunks = [chunk async for chunk in _sse_stream(mock_events(), last_event_id=0)]
+        event_chunks = [c for c in chunks if c != ":\n\n"]
+        assert len(event_chunks) == 2
+
+    @pytest.mark.asyncio
+    async def test_last_event_id_beyond_total_yields_none(self):
+        """If last_event_id exceeds total events, nothing is yielded."""
+        async def mock_events():
+            yield progress_event(node="a")
+
+        chunks = [chunk async for chunk in _sse_stream(mock_events(), last_event_id=99)]
+        event_chunks = [c for c in chunks if c != ":\n\n"]
+        assert len(event_chunks) == 0
+
+
+class TestEventBuffer:
+    """Tests for the ring buffer helpers."""
+
+    def test_buffer_append_within_limit(self):
+        buf: list[tuple[int, str]] = []
+        for i in range(1, 11):
+            _buffer_append(buf, i, f"frame-{i}")
+        assert len(buf) == 10
+        assert buf[0] == (1, "frame-1")
+
+    def test_buffer_evicts_oldest_when_full(self):
+        buf: list[tuple[int, str]] = []
+        for i in range(1, EVENT_BUFFER_MAX_SIZE + 10):
+            _buffer_append(buf, i, f"frame-{i}")
+        assert len(buf) == EVENT_BUFFER_MAX_SIZE
+        # Oldest should have been evicted
+        assert buf[0][0] == 10  # first 9 evicted
+
+    def test_replay_missed_events_filters_correctly(self):
+        buf = [(1, "a"), (2, "b"), (3, "c"), (4, "d")]
+        result = replay_missed_events(buf, after_id=2)
+        assert result == ["c", "d"]
+
+    def test_replay_missed_events_empty_when_caught_up(self):
+        buf = [(1, "a"), (2, "b")]
+        result = replay_missed_events(buf, after_id=5)
+        assert result == []
+
+
+def _parse_sse_body(body: str) -> list[dict]:
+    """Parse SSE text body into list of event dicts."""
+    events = []
+    for block in body.strip().split("\n\n"):
+        block = block.strip()
+        if not block or block == ":":
+            continue
+        data_line = None
+        for line in block.split("\n"):
+            if line.startswith("data: "):
+                data_line = line.removeprefix("data: ")
+        if data_line:
+            try:
+                events.append(json.loads(data_line))
+            except json.JSONDecodeError:
+                continue
+    return events


### PR DESCRIPTION
## Summary
- Adds an endpoint that pulls a nocode-ai adzump session through the gateway and seeds a ds in-memory session with the mapped \`campaign_data\` so downstream ds APIs (keywords, ads, campaign create) can run against an adzump-built campaign.
- Includes the prior chatv2 enhancements (streaming, multi-platform support, test coverage) staged on this branch.

## What's in this PR

**1. Adzump → ds session bridge** (new in \`cdf6790\`)
- \`POST /api/ds/chat/from-adzump-session/{adzump_session_id}\` — UI calls once after the adzump chat ends; ds fetches the session via \`GET /marketingai/{clientCode}/api/ai/adzump/sessions/{id}\` (forwarding the user's auth), maps fields, returns a ds \`session_id\`.
- New module \`services/adzump_session_bridge.py\` with the pure mapping (\`map_adzump_context_to_campaign_data\`), the outbound fetch, and the ds session creation.
- Mapping covers: businessName, websiteURL, budget (digits), durationDays (digits), loginCustomerId, customerId, locations, platform, productSummary, businessType, competitors, accountNames, fbPageId/igAccountId (Meta), plus provenance (adzumpProductId, adzumpSessionId, lat/lng).
- Service raises \`BusinessValidationException\` — caught by the existing global exception handler. Router stays a one-liner.

**2. ChatV2 enhancements** (\`4e0df88\`)
- Streaming, multi-platform support, additional test coverage (per the existing commit on this branch).

## Test plan
- [ ] Unit: pure mapping (\`map_adzump_context_to_campaign_data\`) covers Google + Meta inputs, parses \`"60 days"\` → 60, \`"₹25,000/day"\` → \"25000\", strips dashed customer ids.
- [ ] Integration: with a live adzump session, \`POST /api/ds/chat/from-adzump-session/{id}\` returns a ds session id; \`GET /api/ds/keywords/...\` with that session header succeeds.
- [ ] ChatV2 streaming + multi-platform paths run end-to-end (existing test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)