### PR TITLE
Normalize business_url before storage filter in competitor orchestrator

### DIFF
--- a/services/competitor/competitor_analysis_orchestrator.py
+++ b/services/competitor/competitor_analysis_orchestrator.py
@@ -4,6 +4,7 @@ from structlog import get_logger  # type: ignore
 import structlog.contextvars
 
 from oserver.services.storage_service import storage_service
+from utils.helpers import normalize_url
 from oserver.models.storage_request_model import (
     StorageReadRequest,
     StorageFilter,
@@ -79,12 +80,15 @@ class CompetitorAnalysisOrchestrator:
         self, business_url: str
     ) -> Tuple[Dict[str, Any], str, BusinessMetadata]:
         """Fetch business record and resolve info context."""
-        # 1. Fetch from storage
+        # 1. Fetch from storage. Normalize the URL to match how records are
+        # keyed (lowercase host, no www., no trailing slash, force https).
+        # Without this, e.g. "https://example.com/" misses the record stored
+        # under "https://example.com".
         read_req = StorageReadRequest(
             storageName=self.STORAGE_NAME,
             appCode=self.APP_CODE,
             clientCode=auth_context.client_code,
-            filter=StorageFilter(field="businessUrl", value=business_url),
+            filter=StorageFilter(field="businessUrl", value=normalize_url(business_url)),
         )
         resp = await storage_service.read_page_storage(read_req)
 


### PR DESCRIPTION
## Why
\`_load_business_info\` (services/competitor/competitor_analysis_orchestrator.py:91) filters by \`businessUrl\` without normalizing the incoming URL. Storage records are keyed under the normalized form, so a request URL with a trailing slash or different case raised \`StorageException("Empty record for ...")\`.

Reported case: \`/api/ds/competitor/analyze\` with \`https://subhavillamor.com/\` — record exists keyed as \`https://subhavillamor.com\`, fails to find it.

## Fix
Apply \`normalize_url(business_url)\` before the filter, matching the pattern other ds services already follow (screenshot_service, external_link_summary_service, final_summary_service, pdf_service, business_service all call \`normalize_url\` at their entry points).

## Test plan
- [ ] POST /api/ds/competitor/analyze with \`https://subhavillamor.com/\` → resolves the record (no \`Empty record\` error)
- [ ] Same URL without trailing slash still works
- [ ] Mixed case / www. variants still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)