### PR TITLE
feat(meta/creative): enforce objective-aware CTA validation

### DIFF
--- a/agents/meta/creative_agent.py
+++ b/agents/meta/creative_agent.py
@@ -11,6 +11,9 @@ from core.models.meta import (
     CreateCreativeResponse,
     CallToAction,
     CreativeImage,
+    DestinationType,
+    META_CTA_MAPPING,
+    CampaignObjective,
 )
 from exceptions.custom_exceptions import (
     AIProcessingException,
@@ -49,24 +52,33 @@ def normalize_cta(value: str) -> str:
     return value if value in ALLOWED_CTAS else CallToAction.LEARN_MORE.value
 
 
+def get_valid_ctas(
+    objective: CampaignObjective, destination_type: DestinationType
+) -> str:
+    valid_ctas = META_CTA_MAPPING.get(objective, {}).get(
+        destination_type, [CallToAction.LEARN_MORE]
+    )
+    return ", ".join(cta.value for cta in valid_ctas)
+
+
 class MetaCreativeAgent:
     def __init__(self):
         self.business_service = BusinessService()
         self.creative_adapter = MetaCreativeAdapter()
 
-    async def generate_payload(self, session_id: str) -> LLMCreativeTextPayload:
+    async def generate_payload(
+        self,
+        session_id: str,
+        destination_type: DestinationType,
+    ) -> LLMCreativeTextPayload:
 
         if session_id not in sessions:
             raise BusinessValidationException("Session not found")
 
-        website_data = await self.business_service.fetch_website_data(session_id)
-
-        summary = website_data.final_summary or website_data.summary
+        summary = sessions[session_id].get("campaign_data", {}).get("business_summary")
 
         if not summary:
-            raise BusinessValidationException(
-                "Missing summary in product data. Please complete website analysis."
-            )
+            raise BusinessValidationException("Missing business summary in session.")
 
         strategy_raw = await chat_completion(
             [{"role": "user", "content": STRATEGY_PROMPT.format(summary=summary)}]
@@ -78,12 +90,16 @@ class MetaCreativeAgent:
         sessions[session_id]["campaign_data"]["business_summary"] = summary
         sessions[session_id]["campaign_data"]["visual_strategy"] = strategy_json
 
+        valid_ctas = get_valid_ctas(CampaignObjective.OUTCOME_LEADS, destination_type)
+
         text_raw = await chat_completion(
             [
                 {
                     "role": "user",
                     "content": TEXT_PROMPT.format(
-                        summary=summary, strategy=strategy_json
+                        summary=summary,
+                        strategy=strategy_json,
+                        valid_ctas=valid_ctas,
                     ),
                 }
             ]

--- a/api/meta.py
+++ b/api/meta.py
@@ -4,7 +4,7 @@ from agents.meta.adset_agent import meta_adset_agent
 from utils.response_helpers import success_response
 from core.models.lead_form import LeadFormPayload
 from agents.meta.creative_agent import meta_creative_agent
-from core.models.meta import MetaAdCreationRequest, PlacementRequest
+from core.models.meta import MetaAdCreationRequest, PlacementRequest, CreativeGenerationRequest
 from agents.meta.lead_form_agent import meta_lead_form_agent
 from adapters.meta.ad_creation_orchestrator import MetaAdCreationOrchestrator
 from agents.meta.detailed_targeting_agent import detailed_targeting_agent
@@ -30,8 +30,14 @@ async def generate_adset(
 
 
 @router.post("/creative/generate")
-async def generate_creative(session_id: str = Query(..., alias="sessionId")):
-    result = await meta_creative_agent.generate_payload(session_id)
+async def generate_creative(
+    body: CreativeGenerationRequest,
+    session_id: str = Query(..., alias="sessionId")
+):
+    result = await meta_creative_agent.generate_payload(
+        session_id=session_id,
+        destination_type=body.destination_type
+    )
     return success_response(data=result.model_dump(mode="json"))
 
 

--- a/core/models/meta.py
+++ b/core/models/meta.py
@@ -299,6 +299,10 @@ class LLMCreativeTextPayload(BaseModel):
     image: CreativeImage | None = None
 
 
+class CreativeGenerationRequest(BaseModel):
+    destination_type: DestinationType
+
+
 class CreateCreativeRequest(BaseModel):
     adAccountId: str = Field(..., alias="adAccountId")
     creativePayload: LLMCreativeTextPayload = Field(..., alias="creativePayload")
@@ -737,3 +741,28 @@ class MetaAdsPlacementResponse(BaseModel):
 class PlacementRequest(BaseModel):
     objective: CampaignObjective
     creative_type: CreativeType
+
+
+META_CTA_MAPPING: dict[CampaignObjective, dict[DestinationType, list[CallToAction]]] = {
+    CampaignObjective.OUTCOME_LEADS: {
+        DestinationType.ON_AD: [
+            CallToAction.APPLY_NOW,
+            CallToAction.BOOK_NOW,
+            CallToAction.DOWNLOAD,
+            CallToAction.GET_OFFER,
+            CallToAction.GET_QUOTE,
+            CallToAction.LEARN_MORE,
+            CallToAction.SIGN_UP,
+            CallToAction.SUBSCRIBE,
+        ],
+        DestinationType.WEBSITE: [
+            CallToAction.CONTACT_US,
+            CallToAction.SIGN_UP,
+            CallToAction.GET_QUOTE,
+            CallToAction.BOOK_NOW,
+            CallToAction.APPLY_NOW,
+            CallToAction.LEARN_MORE,
+            CallToAction.SUBSCRIBE,
+        ],
+    }
+}

--- a/prompts/meta/creative_text.txt
+++ b/prompts/meta/creative_text.txt
@@ -16,6 +16,9 @@ Business Summary:
 Creative Strategy:
 {strategy}
 
+Valid CTAs:
+{valid_ctas}
+
 ---
 
 Task:
@@ -92,34 +95,12 @@ Never exceed character limits.
 
 IMPORTANT:
 Return CTA values in UPPER_SNAKE_CASE exactly as required by Meta Ads API.
-Example: SIGN_UP, LEARN_MORE, SHOP_NOW
-
 
 CTA Selection Rules:
-
-Choose ONE CTA that aligns with the campaign goal:
-
-- If goal is "awareness":
-  - Learn More
-  - See More
-
-- If goal is "traffic":
-  - Learn More
-  - Get Started
-  - Download
-
-- If goal is "leads":
-  - Contact Us
-  - Sign Up
-  - Get Quote
-  - Book Now
-  - Apply Now
-
-- If goal is "conversions":
-  - Shop Now
-  - Get Offer
-  - Order Now
-  - Subscribe
+You MUST choose exactly ONE CTA from the "Valid CTAs" list provided above.
+Do NOT use any CTA not in the "Valid CTAs" list.
+Read the business summary and creative strategy carefully.
+Pick the single most contextually relevant CTA that best matches what a user would naturally do after seeing this ad.
 
 ---
 


### PR DESCRIPTION
- Add META_CTA_MAPPING in core/models/meta.py mapping CampaignObjective
  + DestinationType to their valid Meta API CallToAction values
- Add CreativeGenerationRequest model accepting destination_type only; objective is hardcoded to OUTCOME_LEADS internally
- Add get_valid_ctas() helper in creative_agent.py that resolves allowed CTAs from META_CTA_MAPPING with LEARN_MORE as safe fallback
- Update generate_payload() to accept destination_type, compute valid CTAs, and inject them into the LLM prompt
- Replace fetch_website_data() with direct session lookup on business_summary to avoid redundant storage calls
- Update /creative/generate endpoint to accept CreativeGenerationRequest body
- Update creative_text.txt prompt: inject {valid_ctas} dynamically and instruct the LLM to select the most contextually relevant CTA from the provided list only