### PR TITLE
Meta: send is_adset_budget_sharing_enabled=false on campaign create (fixes 4834011)

### DIFF
--- a/agents/meta/payload_builders/basic_entity_builders.py
+++ b/agents/meta/payload_builders/basic_entity_builders.py
@@ -8,6 +8,9 @@ def build_campaign_payload(campaign: CampaignPayload) -> dict:
         "name": build_name(campaign.name, AdCreationStage.CAMPAIGN),
         "objective": campaign.objective.value,
         "status": campaign.status.value,
+        # required by Meta (v24+) when campaign has no budget (ABO);
+        # single adset per campaign → nothing to share, keep spend deterministic
+        "is_adset_budget_sharing_enabled": False,
     }
 
     if campaign.special_ad_categories:

--- a/tests/meta/test_payload_generation.py
+++ b/tests/meta/test_payload_generation.py
@@ -131,6 +131,8 @@ def test_campaign_builder(sample_payload_data):
 
     assert payload["name"].startswith("Life by the Lake")
     assert payload["objective"] == "OUTCOME_LEADS"
+    # required by Meta v24+ for ABO campaigns (no campaign budget)
+    assert payload["is_adset_budget_sharing_enabled"] is False
     # Campaign model conversion to Enum check
     assert SpecialAdCategory.HOUSING in campaign_model.special_ad_categories
     assert "HOUSING" in payload["special_ad_categories"]


### PR DESCRIPTION
## Why
Meta campaign creation started failing on 2026-06-11 with `OAuthException 100 / subcode 4834011` at `failed_stage: CAMPAIGN`:

> "Must specify True or False in is_adset_budget_sharing_enabled field … if you are not using campaign budget."

Meta made this field **required from Marketing API v24** for campaigns without a campaign-level budget (our setup — budget lives on the adset, ABO). Enforcement reached older API versions too, which is why our v22-pinned client broke without any deploy on our side.

## What
- `build_campaign_payload` now sends `is_adset_budget_sharing_enabled: false`
- Test asserts the field

`false` because we create exactly one adset per campaign (nothing to share) and budgets are recommendation-engine-owned — Meta shouldn't reallocate spend. CBO / budget-sharing can become an opt-in scaling mode when multi-adset campaigns exist.

## Notes
- Retry of a failed launch can pass the `creative_id` from the error back via `existing_ids` to reuse the already-created creative
- Follow-up (separate): bump `META_BASE_URL` off v22.0 — old pins don't shield us from cross-version enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
