### PR TITLE
Bump Google Ads API to v23 (v20 sunset) + google-ads 28→29

### DIFF
--- a/adapters/google/client.py
+++ b/adapters/google/client.py
@@ -23,7 +23,7 @@ _google_api_token_expiry: float = 0
 
 class GoogleAdsClient:
     BASE_URL = "https://googleads.googleapis.com"
-    API_VERSION = "v21"
+    API_VERSION = "v23"
 
     def __init__(self) -> None:
         self.developer_token = os.getenv("GOOGLE_ADS_DEVELOPER_TOKEN")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.6
 distro==1.9.0
 dnspython==2.8.0
 fastapi==0.116.1
-google-ads==28.0.0
+google-ads==29.0.0
 google-api-core==2.25.1
 google-auth==2.40.3
 google-auth-oauthlib==1.2.2

--- a/services/create_campaign_service.py
+++ b/services/create_campaign_service.py
@@ -14,7 +14,7 @@ class CampaignServiceError(Exception):
 async def create_and_post_campaign(
     request_body: Dict[str, Any],
     client_code: str,
-    api_version: str = "v20",
+    api_version: str = "v23",
 ) -> Dict[str, Any]:
     """
     1. Build mutate payload using generate_google_ads_mutate_operations

--- a/services/geo_target_service.py
+++ b/services/geo_target_service.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 
 
 class GeoTargetService:
-    GOOGLE_ADS_API_VERSION = "v20"
+    GOOGLE_ADS_API_VERSION = "v23"
     SUGGEST_ENDPOINT = f"https://googleads.googleapis.com/{GOOGLE_ADS_API_VERSION}/geoTargetConstants:suggest"
     GEOCODING_API_URL = "https://maps.googleapis.com/maps/api/geocode/json"
     HTTP_TIMEOUT = 30.0

--- a/services/google_keywords_service.py
+++ b/services/google_keywords_service.py
@@ -130,7 +130,7 @@ class GoogleKeywordService:
             if not developer_token:
                 raise ValueError("GOOGLE_ADS_DEVELOPER_TOKEN is required")
 
-            endpoint = f"https://googleads.googleapis.com/v20/customers/{customer_id}:generateKeywordIdeas"
+            endpoint = f"https://googleads.googleapis.com/v23/customers/{customer_id}:generateKeywordIdeas"
             headers = {
                 "authorization": f"Bearer {access_token}",
                 "developer-token": developer_token,

--- a/services/search_term_pipeline.py
+++ b/services/search_term_pipeline.py
@@ -175,7 +175,7 @@ class SearchTermPipeline:
     # Fetch search terms
     async def fetch_search_terms(self, customer_id: str = None) -> list:
         target_customer_id = customer_id or self.customer_id
-        endpoint = f"https://googleads.googleapis.com/v20/customers/{target_customer_id}/googleAds:search"
+        endpoint = f"https://googleads.googleapis.com/v23/customers/{target_customer_id}/googleAds:search"
         headers = {
             "Authorization": f"Bearer {self.google_ads_access_token}",
             "developer-token": self.developer_token,

--- a/third_party/google/google_utils/google_ads_utils.py
+++ b/third_party/google/google_utils/google_ads_utils.py
@@ -9,7 +9,7 @@ logger = structlog.get_logger(__name__)
 RETRY_ATTEMPTS = 3
 RETRY_DELAY = 5
 BASEURL = "https://googleads.googleapis.com"
-APIVERSION = "v21"
+APIVERSION = "v23"
 
 
 async def execute_google_ads_query(

--- a/third_party/google/services/ads_service.py
+++ b/third_party/google/services/ads_service.py
@@ -29,7 +29,7 @@ async def fetch_ads(
         if not developer_token or not google_ads_access_token:
             raise ValueError("Missing Google Ads credentials or tokens.")
 
-        endpoint = f"https://googleads.googleapis.com/v20/customers/{customer_id}/googleAds:search"
+        endpoint = f"https://googleads.googleapis.com/v23/customers/{customer_id}/googleAds:search"
         headers = {
             "Authorization": f"Bearer {google_ads_access_token}",
             "developer-token": developer_token,

--- a/third_party/google/services/age_service.py
+++ b/third_party/google/services/age_service.py
@@ -21,7 +21,7 @@ async def fetch_age_metrics(
             status_code=401, detail="Missing Google Ads credentials or tokens"
         )
 
-    url = f"https://googleads.googleapis.com/v21/customers/{customer_id}/googleAds:searchStream"
+    url = f"https://googleads.googleapis.com/v23/customers/{customer_id}/googleAds:searchStream"
     headers = {
         "Authorization": f"Bearer {access_token}",
         "developer-token": DEVELOPER_TOKEN,

--- a/third_party/google/services/budget_service.py
+++ b/third_party/google/services/budget_service.py
@@ -10,7 +10,7 @@ async def fetch_audit_logs(customer_id: str, login_customer_id: str, access_toke
     end_date = date.today()
     start_date = end_date - timedelta(days=29)
     
-    url = f"https://googleads.googleapis.com/v21/customers/{customer_id}/googleAds:searchStream"
+    url = f"https://googleads.googleapis.com/v23/customers/{customer_id}/googleAds:searchStream"
     headers = {
         "Authorization": f"Bearer {access_token}",
         "developer-token": DEVELOPER_TOKEN,
@@ -45,7 +45,7 @@ async def fetch_audit_logs(customer_id: str, login_customer_id: str, access_toke
 
 # ---------------------- Fetch Campaign Metrics ----------------------
 async def fetch_campaign_metrics(customer_id: str, login_customer_id: str, access_token: str, campaign_id: str) -> list:
-    url = f"https://googleads.googleapis.com/v21/customers/{customer_id}/googleAds:searchStream"
+    url = f"https://googleads.googleapis.com/v23/customers/{customer_id}/googleAds:searchStream"
     headers = {
         "Authorization": f"Bearer {access_token}",
         "developer-token": DEVELOPER_TOKEN,
@@ -84,7 +84,7 @@ async def fetch_campaign_metrics(customer_id: str, login_customer_id: str, acces
 
 # ---------------------- Fetch Old Budget ----------------------
 async def fetch_old_budget(customer_id: str, login_customer_id: str, access_token: str, campaign_id: str) -> dict:
-    url = f"https://googleads.googleapis.com/v21/customers/{customer_id}/googleAds:search"
+    url = f"https://googleads.googleapis.com/v23/customers/{customer_id}/googleAds:search"
     headers = {
         "Authorization": f"Bearer {access_token}",
         "developer-token": DEVELOPER_TOKEN,

--- a/third_party/google/services/google_ads_client.py
+++ b/third_party/google/services/google_ads_client.py
@@ -10,7 +10,7 @@ async def post_mutate_operations(
     login_customer_id: str,
     mutate_payload: Dict[str, Any],
     client_code: str,
-    api_version: str = "v20",
+    api_version: str = "v23",
     timeout_seconds: int = 30,
 ) -> Dict[str, Any]:
     """

--- a/third_party/google/services/google_customers_accounts.py
+++ b/third_party/google/services/google_customers_accounts.py
@@ -4,7 +4,7 @@ import os
 from typing import Dict, List, Any
 from oserver.services import connection
 
-GOOGLE_ADS_API = "https://googleads.googleapis.com/v20"
+GOOGLE_ADS_API = "https://googleads.googleapis.com/v23"
 
 
 def _get_auth_headers(client_code: str) -> Dict[str, str]:


### PR DESCRIPTION
## Why
Google Ads API **v20 sunset on 2026-06-10** — every request to a `.../v20/...` endpoint now fails with an unsupported-version error. Several ds call-sites were still on v20 (and others on v21), so they're broken/at-risk. Current latest is v24; v23 is supported and one back from latest.

## What
- **REST call-sites → `v23`** (12 files): `adapters/google/client.py`, `third_party/google/{google_utils/google_ads_utils, services/ads_service, services/age_service, services/budget_service, services/google_ads_client, services/google_customers_accounts}`, `services/{create_campaign,geo_target,google_keywords,search_term_pipeline}`.
- **`google-ads` lib `28.0.0` → `29.0.0`** — 28.0.0 only supports up to v21; v23 support lands in 29.0.0 (v22 was 28.1.0). Needed for the lib-based mutation/optimization paths to reach v23.

14 lines changed, version-strings only.

## ⚠️ Testing
The REST string bump is mechanical and low-risk. **The `google-ads 29.0.0` upgrade is NOT yet runtime-tested** — 29.x can carry proto/enum changes (and likely drops an older API version) that affect the mutation/optimization builders. Before merge: `pip install -r requirements.txt` and run the ds test suite / one live Google Ads call to confirm nothing broke.

Sources: [v20 sunset notice](https://ads-developers.googleblog.com/2026/04/google-ads-api-v20-sunset-reminder.html) · [google-ads-python changelog](https://github.com/googleads/google-ads-python/blob/main/ChangeLog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)