### PR TITLE
fix: v23 campaign date_time format (yyyy-mm-dd hh:mm:ss)

### DIFF
--- a/third_party/google/services/build_google_search_ad_payload.py
+++ b/third_party/google/services/build_google_search_ad_payload.py
@@ -27,15 +27,15 @@ def generate_google_ads_mutate_operations(
     budget_number = float(campaign_data_payload.get("budget", 0) or 0)
     amount_micros = int(budget_number * 1_000_000) if budget_number > 0 else None
 
-    # v23: Campaign uses start_date_time/end_date_time (ISO-8601 + tz),
-    # replacing the v22 date-only start_date/end_date. +05:30 = IST account tz;
-    # derive from the customer's time_zone for non-IST accounts.
+    # v23 start_date_time/end_date_time format MUST be "yyyy-mm-dd hh:mm:ss"
+    # (no 'T', no tz offset) — interpreted in the account timezone. start-of-day
+    # / end-of-day.
     start_date = datetime.strptime(
         campaign_data_payload.get("startDate"), "%d/%m/%Y"
-    ).strftime("%Y-%m-%d") + "T00:00:00+05:30"
+    ).strftime("%Y-%m-%d") + " 00:00:00"
     end_date = datetime.strptime(
         campaign_data_payload.get("endDate"), "%d/%m/%Y"
-    ).strftime("%Y-%m-%d") + "T23:59:59+05:30"
+    ).strftime("%Y-%m-%d") + " 23:59:59"
     goal = campaign_data_payload.get("goal", "leads")
     geo_target_type_setting = campaign_data_payload.get("geoTargetTypeSetting")
     locations = campaign_data_payload.get("locations", [])


### PR DESCRIPTION
## Follow-up to #338 — field name was right, format was wrong
After #338, the campaign create now reaches the date fields (no more "Cannot find field"), but v23 rejects the **value format**:

> `INVALID_STRING_DATE_TIME_SECONDS`: "The string date time's format should be **yyyy-mm-dd hh:mm:ss**."

#338 used ISO-8601 with a tz offset (`2026-06-22T00:00:00+05:30`). v23 wants the **space-separated, offset-free** form interpreted in the account timezone.

## Fix
```diff
- ).strftime("%Y-%m-%d") + "T00:00:00+05:30"
- ).strftime("%Y-%m-%d") + "T23:59:59+05:30"
+ ).strftime("%Y-%m-%d") + " 00:00:00"
+ ).strftime("%Y-%m-%d") + " 23:59:59"
```
Bonus: dropping the offset also **removes the hardcoded +05:30** — the format is now account-timezone-local and generic.

## Impact
This was the campaign-create blocker. The ~200 `RESOURCE_NOT_FOUND` errors in the failed response were **cascading** (temp campaign `-2` never created) — they clear once the campaign creates.

## Watch (separate, secondary)
One `structured_snippet_asset … TOO_FEW values` at op 57 — independent of the date fix; Google requires ≥3 values per structured snippet. Revisit if it surfaces after this lands.

## Test
Re-run the campaign create. Date errors should clear and the campaign + downstream ops should create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)