### PR TITLE
fix: Meta adset creation - set advantage_audience flag

### DIFF
--- a/agents/meta/payload_builders/adset_builder/adset_builder.py
+++ b/agents/meta/payload_builders/adset_builder/adset_builder.py
@@ -42,6 +42,8 @@ def _build_targeting(targeting: Targeting) -> dict:
     entity_payload = entity_targeting_builder.build_entity_targeting(targeting)
     meta_targeting.update(entity_payload)
 
+    meta_targeting["targeting_automation"] = {"advantage_audience": 0}
+
     return meta_targeting
 
 


### PR DESCRIPTION
## Summary
- Meta now requires `targeting_automation.advantage_audience` to be explicitly set on adset creation (error subcode 1870227)
- Sets flag to `0` to opt out of Advantage Audience AI expansion, preserving our explicit targeting

## Test plan
- [ ] Create a Meta campaign end-to-end — adset stage should no longer return error 1870227
- [ ] Verify targeting (geo, age, gender, interests) still applies as configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)