### PR TITLE
feat(meta): resolve image URLs to Meta hashes during payload assembly

### DIFF
--- a/agents/meta/meta_payload_service.py
+++ b/agents/meta/meta_payload_service.py
@@ -36,8 +36,9 @@ class MetaPayloadAssemblyService:
             resolved_hashes = await MetaPayloadAssemblyService._resolve_image_hashes(
                 meta_request.ad_account_id, creative_input.image_urls
             )
-            creative_input.image_hashes = resolved_hashes
-
+            # Note: BaseCreative must remain mutable (no frozen=True config) for this assignment.
+            # We explicitly cast resolved_hashes to a list to satisfy type checkers.
+            creative_input.image_hashes = list(resolved_hashes)
 
         is_dynamic_creative = MetaPayloadAssemblyService._is_dynamic_creative(
             creative_input
@@ -91,21 +92,32 @@ class MetaPayloadAssemblyService:
         image_adapter = MetaAdImageAdapter()
 
         async def _upload_single(url: str) -> str:
-            logger.info("Downloading image from URL", url=url)
-            response = await http_request("GET", url)
-            image_base64 = base64.b64encode(response.content).decode("utf-8")
+            try:
+                logger.info("Downloading image from URL", url=url)
+                response = await http_request("GET", url)
+                image_base64 = base64.b64encode(response.content).decode("utf-8")
 
-            logger.info("Uploading image to Meta", url=url)
-            upload_result = await image_adapter.upload_image(
-                ad_account_id=ad_account_id,
-                image_base64=image_base64,
-            )
-            image_data = next(iter(upload_result["images"].values()))
-            image_hash = image_data["hash"]
-            logger.info("Image uploaded successfully", url=url, hash=image_hash)
-            return image_hash
+                logger.info("Uploading image to Meta", url=url)
+                upload_result = await image_adapter.upload_image(
+                    ad_account_id=ad_account_id,
+                    image_base64=image_base64,
+                )
+                
+                images = upload_result.get("images") or {}
+                if not images:
+                    raise ValueError("Meta image upload returned no images")
+                
+                image_data = next(iter(images.values()))
+                image_hash = image_data["hash"]
+                logger.info("Image uploaded successfully", url=url, hash=image_hash)
+                return image_hash
+            except Exception as e:
+                logger.error("Image upload failed", url=url, error=str(e))
+                raise ValueError(f"Failed to upload image {url}: {e}") from e
 
-        return await asyncio.gather(*[_upload_single(url) for url in image_urls])
+        return list(await asyncio.gather(*[_upload_single(url) for url in image_urls]))
+
+
 
     @staticmethod
     def _is_dynamic_creative(creative: CreativePayload) -> bool:

--- a/agents/meta/meta_payload_service.py
+++ b/agents/meta/meta_payload_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 from structlog import get_logger
 from core.models.meta import MetaAdCreationRequest, CreativePayload, AssembledMetaPayloads
 from agents.meta.payload_builders.basic_entity_builders import (
@@ -7,6 +8,9 @@ from agents.meta.payload_builders.basic_entity_builders import (
 )
 from agents.meta.payload_builders.adset_builder.adset_builder import build_adset_payload
 from agents.meta.payload_builders.creative_builder import build_creative_payload
+from core.infrastructure.http_client import http_request
+from adapters.meta.images import MetaAdImageAdapter
+
 
 logger = get_logger(__name__)
 
@@ -20,6 +24,20 @@ class MetaPayloadAssemblyService:
     ) -> AssembledMetaPayloads:
         """Assemble Campaign, AdSet, Creative, and Ad payloads concurrently."""
         creative_input = meta_request.creative
+
+        # Download image URLs, convert to base64, and upload to Meta to get hashes
+        # If creative_id is already present, the creative already exists on Meta and won't be recreated,
+        # so we can skip downloading and uploading the images entirely.
+        creative_id_exists = (
+            meta_request.existing_ids is not None
+            and bool(meta_request.existing_ids.creative_id)
+        )
+        if creative_input.image_urls and not creative_id_exists:
+            resolved_hashes = await MetaPayloadAssemblyService._resolve_image_hashes(
+                meta_request.ad_account_id, creative_input.image_urls
+            )
+            creative_input.image_hashes = resolved_hashes
+
 
         is_dynamic_creative = MetaPayloadAssemblyService._is_dynamic_creative(
             creative_input
@@ -66,12 +84,42 @@ class MetaPayloadAssemblyService:
         )
 
     @staticmethod
+    async def _resolve_image_hashes(
+        ad_account_id: str, image_urls: list[str]
+    ) -> list[str]:
+        """Download image URLs, convert to base64, upload to Meta, and return hashes."""
+        image_adapter = MetaAdImageAdapter()
+
+        async def _upload_single(url: str) -> str:
+            logger.info("Downloading image from URL", url=url)
+            response = await http_request("GET", url)
+            image_base64 = base64.b64encode(response.content).decode("utf-8")
+
+            logger.info("Uploading image to Meta", url=url)
+            upload_result = await image_adapter.upload_image(
+                ad_account_id=ad_account_id,
+                image_base64=image_base64,
+            )
+            image_data = next(iter(upload_result["images"].values()))
+            image_hash = image_data["hash"]
+            logger.info("Image uploaded successfully", url=url, hash=image_hash)
+            return image_hash
+
+        return await asyncio.gather(*[_upload_single(url) for url in image_urls])
+
+    @staticmethod
     def _is_dynamic_creative(creative: CreativePayload) -> bool:
         """Return True if any asset (text/headline/image) has multiple variations."""
+        images_count = 0
+        if creative.image_hashes:
+            images_count = len(creative.image_hashes)
+        elif creative.image_urls:
+            images_count = len(creative.image_urls)
 
         return (
             len(creative.primary_texts) > 1
             or len(creative.headlines) > 1
-            or len(creative.image_hashes) > 1
+            or images_count > 1
             or (creative.descriptions is not None and len(creative.descriptions) > 1)
         )
+

--- a/core/models/meta.py
+++ b/core/models/meta.py
@@ -576,8 +576,11 @@ class BaseCreative(BaseModel):
     page_id: str = Field(..., min_length=1)
     instagram_user_id: str | None = Field(default=None, min_length=1)
     destination_type: DestinationType
-    image_hashes: list[str] = Field(
-        ..., min_length=1, max_length=meta_constants.MAX_IMAGES
+    image_urls: list[str] | None = Field(
+        default=None, max_length=meta_constants.MAX_IMAGES
+    )
+    image_hashes: list[str] | None = Field(
+        default=None, max_length=meta_constants.MAX_IMAGES
     )
     headlines: list[HeadlineStr] = Field(
         ..., min_length=1, max_length=meta_constants.MAX_HEADLINES
@@ -588,6 +591,13 @@ class BaseCreative(BaseModel):
     descriptions: list[DescriptionStr] | None = Field(
         default=None, min_length=1, max_length=meta_constants.MAX_DESCRIPTIONS
     )
+
+    @model_validator(mode="after")
+    def validate_images(self) -> BaseCreative:
+        if not self.image_urls and not self.image_hashes:
+            raise ValueError("Either image_urls or image_hashes must be provided")
+        return self
+
 
 
 class WebsiteCreative(BaseCreative):

--- a/tests/meta/test_payload_generation.py
+++ b/tests/meta/test_payload_generation.py
@@ -79,6 +79,7 @@ def sample_payload_data(future_dates):
             "page_id": "332515906622723",
             "primary_texts": ["Experience lakeside living."],
             "headlines": ["Luxury Villas"],
+            "image_urls": ["https://example.com/image.jpg"],
             "image_hashes": ["b5a136d20f5c4e4d993ada2062936e2f"],
             "destination_type": "WEBSITE",
             "call_to_action": {"type": "LEARN_MORE", "url": "https://lifebythelake.in"},


### PR DESCRIPTION
- Update BaseCreative in core/models/meta.py to accept image_urls and make image_hashes optional, requiring at least one of them.
- Implement _resolve_image_hashes in MetaPayloadAssemblyService to download images, encode to base64, and upload them to Meta.
- Add an optimization to skip image resolution/upload during retries if existing_ids.creative_id is already present.
- Update test fixtures in 	ests/meta/test_payload_generation.py to align with the new schema validation.